### PR TITLE
UMUS-60 Add Site Name plugin.

### DIFF
--- a/src/Plugin/search_api/processor/Property/SiteNameProperty.php
+++ b/src/Plugin/search_api/processor/Property/SiteNameProperty.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Drupal\search_api_federated_solr\Plugin\search_api\processor\Property;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\search_api\Item\FieldInterface;
+use Drupal\search_api\Processor\ConfigurablePropertyBase;
+
+/**
+ * Defines a "site name" property.
+ *
+ * @see \Drupal\search_api\Plugin\search_api\processor\SiteName
+ */
+class SiteNameProperty extends ConfigurablePropertyBase {
+
+  use StringTranslationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+      'site_name' =>  \Drupal::config('system.site')->get('name'),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(FieldInterface $field, array $form, FormStateInterface $form_state) {
+    $configuration = $field->getConfiguration();
+
+    $form['#attached']['library'][] = 'search_api/drupal.search_api.admin_css';
+    $form['#tree'] = TRUE;
+
+    $form['site_name'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Site Name'),
+      '#description' => $this->t('The name of the site from which this content originated. This can be useful if indexing multiple sites with a single search index.'),
+      '#default_value' => $configuration['site_name'],
+      '#required' => TRUE,
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(FieldInterface $field, array &$form, FormStateInterface $form_state) {
+    $values = [
+      'site_name' => $form_state->getValue('site_name'),
+    ];
+    $field->setConfiguration($values);
+  }
+
+}

--- a/src/Plugin/search_api/processor/SiteName.php
+++ b/src/Plugin/search_api/processor/SiteName.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Drupal\search_api_federated_solr\Plugin\search_api\processor;
+
+use Drupal\search_api\Datasource\DatasourceInterface;
+use Drupal\search_api\Item\ItemInterface;
+use Drupal\search_api\Processor\ProcessorPluginBase;
+use Drupal\search_api\Processor\ProcessorProperty;
+use Drupal\search_api_federated_solr\Plugin\search_api\processor\Property\SiteNameProperty;
+
+
+/**
+ * Adds the site name to the indexed data.
+ *
+ * @SearchApiProcessor(
+ *   id = "site_name",
+ *   label = @Translation("Site name"),
+ *   description = @Translation("Adds the site name to the indexed data."),
+ *   stages = {
+ *     "add_properties" = 0,
+ *   },
+ *   locked = true,
+ *   hidden = true,
+ * )
+ */
+class SiteName extends ProcessorPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL) {
+    $properties = [];
+
+    if (!$datasource) {
+      $definition = [
+        'label' => $this->t('Site Name'),
+        'description' => $this->t('The name of the site from which this content originated.'),
+        'type' => 'string',
+        'processor_id' => $this->getPluginId(),
+      ];
+      $properties['site_name'] = new SiteNameProperty($definition);
+    }
+
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addFieldValues(ItemInterface $item) {
+    $fields = $this->getFieldsHelper()
+      ->filterForPropertyPath($item->getFields(), NULL, 'site_name');
+    foreach ($fields as $field) {
+      $site_name = $field->getConfiguration()['site_name'];
+      $field->addValue($site_name);
+    }
+  }
+
+}

--- a/src/Plugin/search_api/processor/SiteNameLink.php
+++ b/src/Plugin/search_api/processor/SiteNameLink.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Drupal\search_api_federated_solr\Plugin\search_api\processor;
+
+use Drupal\Core\Link;
+use Drupal\Core\Url;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\PluginFormInterface;
+use Drupal\search_api\Plugin\PluginFormTrait;
+use Drupal\search_api\Processor\ProcessorPluginBase;
+use Drupal\search_api\Query\ResultSetInterface;
+
+/**
+ * Links the base url with the site name.
+ *
+ * @SearchApiProcessor(
+ *   id = "site_name_link",
+ *   label = @Translation("Site name link"),
+ *   description = @Translation("Links the base url with the site name."),
+ *   stages = {
+ *     "postprocess_query" = 0
+ *   }
+ * )
+ */
+class SiteNameLink extends ProcessorPluginBase implements PluginFormInterface {
+
+  use PluginFormTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+
+    $form['description'] = [
+      '#type' => 'item',
+      '#description' => $this->t('This processor provides no configuration options.'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function postprocessSearchResults(ResultSetInterface $results) {
+    $query = $results->getQuery();
+    if (!$results->getResultCount()) {
+      return;
+    }
+
+    $result_items = $results->getResultItems();
+    foreach ($result_items as $key => $item) {
+      $site = $item->getExtraData('search_api_solr_document')['site'];
+      $url = Url::fromUri($site);
+      $name = $item->getField('site_name')->getValues()[0];
+      $link = Link::fromTextAndUrl(t($name), $url)->toString();
+      $item->getField('site_name')->setValues([$link]);
+    }
+  }
+
+}


### PR DESCRIPTION
Adds a Search API plugin to set the site name as a new field to be indexed by Solr. This allows for per-site faceting.

![search_api_absolute_url](https://user-images.githubusercontent.com/238201/34887855-8e6edbea-f78d-11e7-9214-41b936d0e790.gif)

Also add a Search API SiteNameLink postprocessor to link up the site with the site_name in the results.
<img width="316" alt="manage_processors_for_search_index_federated_measured_search_index___university_of_michigan" src="https://user-images.githubusercontent.com/238201/34894158-d85e69ce-f7a5-11e7-8833-9887a2b9ab1c.png">

<img width="354" alt="federated_search_results___university_of_michigan" src="https://user-images.githubusercontent.com/238201/34894126-b9737b12-f7a5-11e7-9aea-3bbf930b413a.png">

## To test
- build labblog and healthblog sites on `UMUS-30_Federated_Search` branch from Acquia
- `drush @healthblog.lab.local cim -y`
- visit https://labblog.uofmhealth.local/solr-search
- search for "cancer" or "healthful diet" or a term of your choosing
- observe site facets
- observe links to sites in results