### PR TITLE
UMUS-91 Add image style to module

### DIFF
--- a/config/install/image.style.search_api_federated_solr_image.yml
+++ b/config/install/image.style.search_api_federated_solr_image.yml
@@ -1,0 +1,13 @@
+langcode: en
+status: true
+dependencies: {  }
+name: search_api_federated_solr_image
+label: 'Federated image'
+effects:
+  53bfd1aa-5a4e-4750-b0d2-1a1ae1f04bce:
+    uuid: 53bfd1aa-5a4e-4750-b0d2-1a1ae1f04bce
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 425
+      height: 239


### PR DESCRIPTION
[UMUS-91](https://palantir.atlassian.net/browse/UMUS-91)
 
Adds image style to the module as per https://www.drupal.org/docs/8/theming-drupal-8/including-default-image-styles-with-your-theme

## To test:

- checkout this branch in `src/search_api_federated_solr`
- `drush @healthblog.lab.local pmu search_api_federated_solr -y`
- `drush @healthblog.lab.local en search_api_federated_solr -y`
- observe new image style at https://labblog.uofmhealth.local/admin/config/media/image-styles/manage/search_api_federated_solr_image

<img width="1040" alt="edit_style_federated_image___university_of_michigan" src="https://user-images.githubusercontent.com/238201/37620864-726a0e9c-2b8b-11e8-9625-d93e0d50cd10.png">

- Observe image matches spec in https://github.com/palantirnet/umus/pull/26
