### PR TITLE
UMUS-94: map site name, url, federated_field to solr single value

### DIFF
--- a/search_api_federated_solr.module
+++ b/search_api_federated_solr.module
@@ -47,5 +47,11 @@ function search_api_federated_solr_search_api_solr_field_mapping_alter(\Drupal\s
     if (array_key_exists($key,$singleFieldsMap)) {
       $fields[$key] = $singleFieldsMap[$key];
     }
+    
+    // Map all "federated_field" property fields to their single value in solr.
+    $field = $index->getField($key);
+    if (method_exists($field,'getPropertyPath') && 'federated_field' == $field->getPropertyPath()) {
+      $fields[$key] = str_replace("m_federated_","s_federated_", $fields[$key]);
+    }
   };
 }


### PR DESCRIPTION
See [UMUS-94](https://palantir.atlassian.net/browse/UMUS-94)

**Description**
This PR maps site name, url, and federated field property field instances to their corresponding solr single value.

**To test**
- checkout `develop` in umus site repo
- checkout this branch in `src/search_api_federated_solr`
- `drush @healthblog.lab.local pmu search_api_federated_solr -y`
- `drush @healthblog.lab.local en search_api_federated_solr -y`
- `drush @healthblog.lab.local cim -y`
- browse to https://labblog.uofmhealth.local/admin/config/search/search-api/index/federated_search_index/fields and confirm there are site_name, url, and federated_field instances in the index field config
- edit an article node to add a unique string to the body text (i.e. `supercalifragilistic`, so that you have something by which to filter in the solr admin ui) 
- publish that article node
- browse to https://ss826806-us-east-1-aws.measuredsearch.com/solr/#/master/query
- add `tm_rendered_item:<your random text i.e. supercalifragilistic>`
- execute the query
- confirm that you see url and site name mapped to single values:
    - `ss_url`
    - `ss_site_name`
- confirm that the federated_field instances are now mapped to single values:
    - `ss_federated_title`
    - `ds_federated_date`
    - `ss_federated_type`
    - `ss_federated_image`

**Screenshot**
<img width="1440" alt="umus-94-fields" src="https://user-images.githubusercontent.com/3279883/38138191-85973a02-33f7-11e8-83d9-7ac776ede29b.png">

<img width="920" alt="umus-94-solr" src="https://user-images.githubusercontent.com/3279883/38138201-8c6fc696-33f7-11e8-89dc-860f0865cd94.png">

**Helpful d.o issue**
https://www.drupal.org/node/2906905
