### PR TITLE
UMUS-110: Avoid indexing raw token strings when token value is empty

### DIFF
--- a/src/Plugin/search_api/processor/FederatedFields.php
+++ b/src/Plugin/search_api/processor/FederatedFields.php
@@ -72,10 +72,12 @@ class FederatedFields extends ProcessorPluginBase {
       // If there's a config item for the entity and bundle type we're in, set the value for the field.
       if(!empty($configuration['field_data'][$entity_type][$bundle_type])) {
         $token = \Drupal::token();
-        $value = $token->replace($configuration['field_data'][$entity_type][$bundle_type], [$entity_type => $entity]);
+        // If the token replacement produces a value, add to this item.
+        if ($value = $token->replace($configuration['field_data'][$entity_type][$bundle_type], [$entity_type => $entity], ['clear' => true])) {
+          // Do not use setValues(), since that doesn't preprocess the values according to their data type.
+          $federated_field->addValue($value);
+        }
 
-        // Do not use setValues(), since that doesn't preprocess the values according to their data type.
-        $federated_field->addValue($value);
       }
     }
   }


### PR DESCRIPTION
[UMUS-110](https://palantir.atlassian.net/browse/UMUS-110)

This PR updates the token replacement invocation in the federated field property to clear the token string when there is no value generated.

## To Test:

- check out and pull the `unified-search` branch in `umus/web/umichphysd8`
- checkout this branch in `src/search_api_federated_solr`
- `drush @healthblog.consumer.local cim -y`(to ensure you get the existing index config)
- `drush @healthblog.consumer.local cr`
- Find a buggy node in the styleguide search app
    - Browse to https://palantirnet.github.io/umus/templates/solr-react/?q=bones
    - Apply the `Type` > `Multimedia` facet
    - Inspect one of the results which is not aligned left (as the first result is) and observe the image src is the token text
        ![image](https://user-images.githubusercontent.com/3279883/39581768-55e170d8-4eba-11e8-94e1-1c43a100ae17.png)
- `drush @healthblog.consumer.local uli` to log in to the site
- republish the buggy node
- refresh the search app
- observe the markup for the image is no longer rendered and the buggy node is now aligned with the first result

