### PR TITLE
UMUS-131 Clear token if no value

### DIFF
--- a/src/SearchApiFederatedSolrField.php
+++ b/src/SearchApiFederatedSolrField.php
@@ -28,7 +28,9 @@ class SearchApiFederatedSolrField extends SearchApiAbstractAlterCallback {
       $bundle = $entity->{$entity_info['entity keys']['bundle']};
       foreach ($this->options['fields'] as $field) {
         if (isset($field['bundle'][$bundle])) {
-          $item->{$field['machine_name']} = token_replace($field['bundle'][$bundle], [$entity_type => $entity]);
+          if($value = token_replace($field['bundle'][$bundle], [$entity_type => $entity], ['clear' => true])) {
+            $item->{$field['machine_name']} = $value;
+          }
         }
       }
     }


### PR DESCRIPTION
Duplicates https://github.com/palantirnet/search_api_federated_solr/pull/14/files in D7.

To test:
- before pulling this branch, edit a token in a federated field to something invalid, like `[node:field_physician_photo:1]`
- index a node using the field and observe the token is sent directly to the index
- pull this PR
- re-index the node
-observe the uncleared token value is gone