### PR TITLE
UMUS-123: adds function to check and validate path format

### DIFF
--- a/search_api_federated_solr.module
+++ b/search_api_federated_solr.module
@@ -242,11 +242,11 @@ function search_api_federated_solr_admin($form, &$form_state) {
  * Create search_api_federated_solr_form_alter to validate the search path format.
  */
 
-function search_api_federated_solr_form_alter(&$form, &$form_state, $form_id) {
-  $form['#validate'][] = 'search_api_federated_solr_path_form_validate';
+function search_api_federated_solr_form_search_api_federated_solr_admin_alter(&$form, &$form_state, $form_id) {
+  $form['#validate'][] = '_path_form_validate';
 }
 
-function search_api_federated_solr_path_form_validate($form, &$form_state) {
+function _path_form_validate($form, &$form_state) {
      $form_state['values']['search_api_federated_solr_path'] = trim($form_state['values']['search_api_federated_solr_path'], '/');
 }
 


### PR DESCRIPTION
Jira-ticket: [UMUS-123: Add check to validate search path format](https://palantir.atlassian.net/browse/UMUS-123)

## Description
Adds a function that checks for a forward slash `/` at the beginning of the path and then removes it.

### Testing

The easiest way to test would be to get a copy of the `search_api_federated_solr.module` or the code, and copy it into the `search_api_federated_solr.module` into the UMUS site/repo, then navigate to (https://www.uofmhealth.local/admin/config/search/search_api/search-api-federated-solr/search-app/settings) input the search path with a `/` and check that it will be stripped after saving the configuration.
