### PR TITLE
UMUS-132: Pass default site name as a qs param from search form

### DIFF
--- a/search_api_federated_solr.module
+++ b/search_api_federated_solr.module
@@ -290,9 +290,6 @@ function search_api_federated_solr_config_json() {
 
   $is_site_name_property = variable_get('search_api_federated_solr_has_site_name_property');
   $set_default_site = variable_get('search_api_federated_solr_set_search_site');
-  if ($is_site_name_property == 'true' && $set_default_site) {
-    $response_data['siteSearch'] = variable_get('site_name');
-  }
   if ($is_site_name_property == 'true' && !$set_default_site) {
     variable_set('search_api_federated_solr_set_search_site', 0);
   }


### PR DESCRIPTION
This PR updates the search app form to send the sitename filter param + value in the form action.

### To test
1. Build a new version of the static assets from this tickets corresponding search app pr branch: https://github.com/palantirnet/federated-search-react/pull/10
1. Copy the output from the build > static directory into the D7 module directory (your git status should reflect changes to the JS library files)
1. Update the JS library file definition in the module `.module` file > `search_api_federated_solr_library()`
1. Rebuild the D7 site cache
1. Log in to a D7 site
1. Make sure the search app is configured to use the federated search index and to set a default the site name
1. Make sure the federated search index has the site name configured
1. Make sure the federated search block is placed in the header of the site theme
1. On the site front end http://www.uofmhealth.local/, search from the header search form
1. Observe the url should contain the qs param `ss_site_name=<your site>`

### To do
Once https://github.com/palantirnet/federated-search-react/pull/10 is merged and a package is deployed; update the search app package version to point to that; update the libaries.yml file accordingly and commit