### PR TITLE
UMUS-139 add userpass

### DIFF
--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -29,6 +29,10 @@ class SearchController extends ControllerBase {
     // REQUIRED: The default solr backend.
     $federated_search_app_config['url'] = $config->get('index.server_url');
 
+    // OPTIONAL: The username and password for Basic Authentication on the server.
+    // The username and password will be combined and base64 encoded as per the application.
+    $federated_search_app_config['userpass'] = base64_encode($config->get('index.username') . ':' . $config->get('index.password'));
+
     // Validate that there is still a site name property set for this index.
     $site_name_property = $index_config->get('field_settings.site_name.configuration.site_name');
     $config->set('index.has_site_name_property', $site_name_property ? true : false);

--- a/src/Form/SearchApiFederatedSolrSearchAppSettingsForm.php
+++ b/src/Form/SearchApiFederatedSolrSearchAppSettingsForm.php
@@ -77,6 +77,24 @@ class SearchApiFederatedSolrSearchAppSettingsForm extends ConfigFormBase {
       '#value' => $config->get('index.has_site_name_property') ? 'true' : '',
     ];
 
+    $form['search_index_basic_auth'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Search Index Basic Authentication'),
+      '#description' => $this->t('If your Solr server is protected by basic HTTP authentication, enter the login data here. This will be accessible to the client in an obscured, but non-secure method. It should, therefore, only provide read access to the index AND be different from that provided when configuring the server in Search API. The Password field is intentionally not obscured to emphasize this distinction.')
+    ];
+
+    $form['search_index_basic_auth']['username'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Username'),
+      '#default_value' => $config->get('index.username'),
+    ];
+
+    $form['search_index_basic_auth']['password'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Password'),
+      '#default_value' => $config->get('index.password'),
+    ];
+    
     $form['set_search_site'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Set the "Site name" facet to this site'),
@@ -176,6 +194,10 @@ class SearchApiFederatedSolrSearchAppSettingsForm extends ConfigFormBase {
 
     // Set the search app configuration setting for the solr backend url.
     $config->set('index.server_url', $server_url);
+
+    // Set the Basic Auth username and password.
+    $config->set('index.username', $form_state->getValue('username'));
+    $config->set('index.password', $form_state->getValue('password'));
 
     // Set the no results text.
     $config->set('content.no_results', $form_state->getValue('no_results_text'));


### PR DESCRIPTION
Adds Username and Password fields to the Search API Federated Solr config page, encodes those and writes them out to the app config.
<img width="1057" alt="search_api_solr_federated__search_app_settings___university_of_michigan" src="https://user-images.githubusercontent.com/238201/41742012-5d1d1540-7562-11e8-9b86-e9d9c0ef36c5.png">


To test:
- visit https://labblog.uofmhealth.local/admin/config/search-api-federated-solr/search-app/settings
- Observe the new fields
- Read the words below
- Enter the username/pass
- Observe the username/pass are written out to the app config:
<img width="654" alt="search___university_of_michigan" src="https://user-images.githubusercontent.com/238201/41742060-854b1cf6-7562-11e8-8cc0-3cc44c73764a.png">
- If you're adventurous: build https://github.com/palantirnet/federated-search-react/pull/11/, copy the generated JS, and replace the js in here. Refresh, see things working.

This also shouldn't be merged until the proper JS is committed into the two dependent repos and pulled in.