### PR TITLE
UMUS-139 d7 add userpass

### DIFF
--- a/search_api_federated_solr.module
+++ b/search_api_federated_solr.module
@@ -294,6 +294,12 @@ function search_api_federated_solr_config_json() {
     $response_data['url'] = $server_url;
   }
 
+  $basic_auth_username = variable_get('search_api_federated_solr_search_index_basic_auth_username');
+  $basic_auth_password = variable_get('search_api_federated_solr_search_index_basic_auth_password');
+  if ($basic_auth_username || $basic_auth_password) {
+    $response_data['userpass'] = base64_encode($basic_auth_username . ':' . $basic_auth_password);
+  }
+
   $is_site_name_property = variable_get('search_api_federated_solr_has_site_name_property');
   $set_default_site = variable_get('search_api_federated_solr_set_search_site');
   if ($is_site_name_property == 'true' && $set_default_site) {


### PR DESCRIPTION
Adds Username and Password fields to the Search API Federated Solr config page, encodes those and writes them out to the app config.
<img width="1057" alt="search_api_solr_federated__search_app_settings___university_of_michigan" src="https://user-images.githubusercontent.com/238201/41742012-5d1d1540-7562-11e8-9b86-e9d9c0ef36c5.png">


To test:
- visit http://www.uofmhealth.local/admin/config/search/search_api/search-api-federated-solr/search-app/settings
- Observe the new fields
- Read the words below
- Enter the username/pass
- Observe the username/pass are written out to the app config:
<img width="654" alt="search___university_of_michigan" src="https://user-images.githubusercontent.com/238201/41742060-854b1cf6-7562-11e8-8cc0-3cc44c73764a.png">
- If you're adventurous: build https://github.com/palantirnet/federated-search-react/pull/11/, copy the generated JS, and replace the js in here. Refresh, see things working.

This also shouldn't be merged until the proper JS is committed into the two dependent repos and pulled in.