### PR TITLE
remove underscores from public methods

### DIFF
--- a/src/Form/SearchApiFederatedSolrSearchAppSettingsForm.php
+++ b/src/Form/SearchApiFederatedSolrSearchAppSettingsForm.php
@@ -36,7 +36,7 @@ class SearchApiFederatedSolrSearchAppSettingsForm extends ConfigFormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $form['#validate'][] = [$this, '_form_validation_path_validate'];
+    $form['#validate'][] = [$this, 'form_validation_path_validate'];
 
     $config = $this->config('search_api_federated_solr.search_app.settings');
 
@@ -247,7 +247,7 @@ class SearchApiFederatedSolrSearchAppSettingsForm extends ConfigFormBase {
    * @param $form
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    */
-  public function _form_validation_path_validate(&$form, FormStateInterface $form_state) {
+  public function form_validation_path_validate(&$form, FormStateInterface $form_state) {
     $path = $form_state->getValue('path');
     if ($path) {
       // Check if a route with the config path value already exists.


### PR DESCRIPTION
https://palantir.atlassian.net/browse/PL-35

##Description

Find and replace calls for _form_validation_path_validate as it violates convention to have a public method named with an underscore.

##To Test

1. find all instances of `form_validation_path_validate` and make sure they do not lead with an underscore.