### PR TITLE
PL-29: Document that example CSS is an example

### DIFF
--- a/docs/theme.md
+++ b/docs/theme.md
@@ -52,3 +52,7 @@ function <your-theme>_page_attachments_alter(array &$page) {
   }
 }
 ```
+
+### Notes
+
+The Sass/CSS assets that are included in docs/assets are examples only. They will not be regularly maintained or updated.


### PR DESCRIPTION
See ticket [PL-29](https://palantir.atlassian.net/browse/PL-29)

Updates the documentation to indicate that the example CSS/Sass provided in docs/assets is example only, and not maintained.