### PR TITLE
UMUS-21 Pass domain hostname to react

### DIFF
--- a/search_api_federated_solr.module
+++ b/search_api_federated_solr.module
@@ -464,13 +464,13 @@ function search_api_federated_solr_library() {
     'title' => 'Federated Search App',
     'version' => variable_get('css_js_query_string', '0'),
     'js' => array(
-      'https://rawgit.com/palantirnet/federated-search-react/v1.0.7/js/main.8f376943.js' => array(
+      'https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v1.0.7/js/main.8f376943.js' => array(
         'type' => 'external',
         'scope' => 'footer',
       ),
     ),
     'css' => array(
-      'https://rawgit.com/palantirnet/federated-search-react/v1.0.7/css/main.cf6a58ce.css' => array(
+      'https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v1.0.7/css/main.cf6a58ce.css' => array(
         'type' => 'external',
       ),
     ),

--- a/search_api_federated_solr.module
+++ b/search_api_federated_solr.module
@@ -355,6 +355,13 @@ function search_api_federated_solr_config_json() {
     $response_data['paginationButtons'] = $pagination_buttons;
   }
 
+  if (function_exists('domain_get_domain')) {
+    $domain = domain_get_domain();
+    if (isset($domain['path'])) {
+      $response_data['hostname'] =  parse_url($domain['path'], PHP_URL_HOST) ;
+    }
+  }
+
   return json_encode($response_data, JSON_UNESCAPED_SLASHES | JSON_NUMERIC_CHECK);
 }
 

--- a/src/SearchApiFederatedSolrSiteName.php
+++ b/src/SearchApiFederatedSolrSiteName.php
@@ -63,7 +63,7 @@ class SearchApiFederatedSolrSiteName extends SearchApiAbstractAlterCallback {
       $ds = [];
       foreach ($domains as $domain_id => $url ) {
         $domain = domain_lookup($domain_id);
-        $ds[] = $domain['sitename'];
+        $ds[] = !empty($this->options['domain'][$domain['machine_name']]) ? $this->options['domain'][$domain['machine_name']] : $domain['sitename'];
       }
       
       $item->site_name = $ds;


### PR DESCRIPTION
This adds a new `hostname` config item to the data-attribute JSON in order to make the domain-based link matching work more reliably.

To test:
- Bring up `uofmhealth.local`
- Load `/search-app`
- Observe in the `#root` `data-federated-search-app-config` contains `"hostname":"uofmhealth.org"`
- Index an item and observe the site links reflect the sitenames in https://www.uofmhealth.local/admin/config/search/search_api/index/federated_search/workflow, not the domain setup.

<img width="837" alt="search___michigan_medicine" src="https://user-images.githubusercontent.com/238201/46885392-765d4e80-ce1d-11e8-8629-1ef7151ae3ea.png">


To-do:
- [x] see if it's possible to refactor domain names passed to the index so that we pull from the ones from the index instead of from Domain config.