### PR TITLE
Change from rawgit to jsdelivr

### DIFF
--- a/search_api_federated_solr.libraries.yml
+++ b/search_api_federated_solr.libraries.yml
@@ -2,9 +2,9 @@ search:
   version: 1.x
   css:
     theme:
-      https://rawgit.com/palantirnet/federated-search-react/v1.0.7/css/main.cf6a58ce.css: { type: external, minified: true }
+      https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v1.0.7/css/main.cf6a58ce.css: { type: external, minified: true }
   js:
-    https://rawgit.com/palantirnet/federated-search-react/v1.0.7/js/main.8f376943.js: {
+    https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v1.0.7/js/main.8f376943.js: {
       preprocess: false,
       minified: true,
     }


### PR DESCRIPTION
https://rawgit.com/ is going away. Let's get ahead of the game.