### PR TITLE
UMHS-24 Use altered site names in search block

### DIFF
--- a/search_api_federated_solr.module
+++ b/search_api_federated_solr.module
@@ -156,7 +156,30 @@ function search_api_federated_solr_search_block_form_submit($form, &$form_state)
   $is_site_name_property = variable_get('search_api_federated_solr_has_site_name_property');
   $set_default_site = variable_get('search_api_federated_solr_set_search_site');
   if ($is_site_name_property == 'true' && $set_default_site) {
-    $qs_params['sm_site_name'] = variable_get('site_name');
+
+    $search_index = variable_get('search_api_federated_solr_search_index');
+    // Get the index configuration object.
+    $index = search_api_index_load($search_index);
+    // Get the domain machine name from Domain Access.
+    if (function_exists('domain_get_domain')) {
+      $domain = domain_get_domain()['machine_name'];
+    }
+
+    // If the site is using Domain Access and there's an altered site name.
+    if (isset($domain) && !empty($index->options['data_alter_callbacks']['site_name']['settings']['domain'][$domain])) {
+      // Lookup the altered site name matching the domain and set it.
+      $domain_site_name = $index->options['data_alter_callbacks']['site_name']['settings']['domain'][$domain];
+      $qs_params['sm_site_name'] = $domain_site_name;
+    }
+    // If no Domain Access, again, check for an altered Site Name.
+    elseif (!empty($index->options['data_alter_callbacks']['site_name']['settings']['site_name'])) {
+      $site_name = $index->options['data_alter_callbacks']['site_name']['settings']['site_name'];
+      $qs_params['sm_site_name'] = $site_name;
+    }
+    // If all else fails, use the site default.
+    else {
+      $qs_params['sm_site_name'] = variable_get('site_name');
+    }
   }
 
   // Redirect to the search app path with necessary qs params.


### PR DESCRIPTION
See https://palantir.atlassian.net/browse/UMHS-24

- pull down https://github.com/palantirnet/umus/pull/42 and follow the instructions
- visit https://mott.umhealth.local.sandbox/
- run `drush @uofmhealth.local.mott uli` to get a login
- at https://mott.umhealth.local.sandbox/admin/structure/block, enable the "Federated Search Page Form block" and add to the Header section
- go back to the homepage and see that the search box is working. It won't actually return results because this url isn't whitelisted for CORS on the Solr server, but you should see the search term come in.
<img width="951" alt="search___cs_mott_children_s_hospital___michigan_medicine" src="https://user-images.githubusercontent.com/238201/48497520-e7679b80-e7f9-11e8-8d5b-288163de8892.png">
- visit the Federated search config https://mott.umhealth.local.sandbox/admin/config/search/search_api/search-api-federated-solr/search-app/settings and enable "Set the site name facet for this site"
- go back to the homepage and search again from the search box, you should see the search filtered by site name.
<img width="583" alt="search___cs_mott_children_s_hospital___michigan_medicine" src="https://user-images.githubusercontent.com/238201/48497767-6b218800-e7fa-11e8-96d8-158e270f7272.png">
- visit https://mott.umhealth.local.sandbox/admin/config/search/search_api/index/federated_search/workflow and change the site name for Mott in the "Callback settings", save, clear caches, and try your search again. You should see the new sitename come through.

### Bonus testing - confirm this works without domain access:

- open `/search_api_federated_solr-7.x/src/SearchApiFederatedSolrSiteName.php`, and edit line 111 to say `return FALSE;`
- open `src/search_api_federated_solr-7.x/search_api_federated_solr.module` and edit line 169 to say `if (FALSE)` so that we skip to the next contitional
- (you might be able to just turn off Domain Access, but I don't have any idea what that might do)
- visit https://www.uofmhealth.local and go through the steps above to enable the search box, set the Federated Search site name setting, set a site name in the Search API config, then search from the search box to see if it's coming through.
- Remove the site name from the Search API config and re-test to see that the main site name from https://www.uofmhealth.local/admin/config/system/site-information is coming through.
