### PR TITLE
Pl 10 add config option to allow for empty search

### DIFF
--- a/search_api_federated_solr.libraries.yml
+++ b/search_api_federated_solr.libraries.yml
@@ -2,9 +2,9 @@ search:
   version: 1.x
   css:
     theme:
-      https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v1.0.9/css/main.cf6a58ce.css: { type: external, minified: true }
+      https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v1.0.10/css/main.cf6a58ce.css: { type: external, minified: true }
   js:
-    https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v1.0.9/js/main.b294abb7.js: {
+    https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v1.0.10/js/main.d41fc3fe.js: {
       preprocess: false,
       minified: true,
     }

--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -62,6 +62,11 @@ class SearchController extends ControllerBase {
       $federated_search_app_config['noResults'] = $no_results;
     }
 
+    // OPTIONAL: The text to display when a search returns no results.
+    if ($show_empty_search_results = $config->get('content.show_empty_search_results')) {
+      $federated_search_app_config['showEmptySearchResults'] = $show_empty_search_results;
+    }
+
     // OPTIONAL: The number of search results to show per page.
     if ($rows = $config->get('results.rows')) {
       $federated_search_app_config['rows'] = intval($rows);

--- a/src/Form/SearchApiFederatedSolrSearchAppSettingsForm.php
+++ b/src/Form/SearchApiFederatedSolrSearchAppSettingsForm.php
@@ -119,6 +119,14 @@ class SearchApiFederatedSolrSearchAppSettingsForm extends ConfigFormBase {
       ],
     ];
 
+    $form['show_empty_search_results'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Show results for empty search'),
+      '#default_value' => $config->get('content.show_empty_search_results'),
+      '#description' => $this
+        ->t(' When checked, this option allows users to see all results when no search term is entered. By default, empty searches are disabled and yield no results.'),
+    ];
+
     $form['no_results_text'] = [
       '#type' => 'textfield',
       '#title' => $this->t('No results text'),
@@ -179,6 +187,10 @@ class SearchApiFederatedSolrSearchAppSettingsForm extends ConfigFormBase {
     // Set the search app config setting for the default search site flag.
     $set_search_site = $form_state->getValue('set_search_site');
     $config->set('facet.site_name.set_default', $set_search_site);
+
+    // Set the search app configuration setting for the default search site flag.
+    $show_empty_search_results = $form_state->getValue('show_empty_search_results');
+    $config->set('content.show_empty_search_results', $show_empty_search_results);
 
     // Get the id of the chosen index.
     $search_index = $form_state->getValue('search_index');


### PR DESCRIPTION
[PL-10](https://palantir.atlassian.net/browse/PL-10)

## Ticket Description
Add "Show results for empty search" (`empty-search-results` or something) option to federated-search-react and create the corresponding config option search_api_federated_solr D8 and D7 branches. This should be a boolean that defaults to false.
Reconfigure react components to behave based on that config.

## PR Description
This PR adds the s`how_empty_search_results` config to the drupal settings form for federated search

## To Test (from federated-search-react repo)
1. Dependent on https://github.com/palantirnet/federated-search-react/pull/25