### PR TITLE
Pl 10 add config option to allow for empty search d7

### DIFF
--- a/search_api_federated_solr.module
+++ b/search_api_federated_solr.module
@@ -498,13 +498,13 @@ function search_api_federated_solr_library() {
     'title' => 'Federated Search App',
     'version' => variable_get('css_js_query_string', '0'),
     'js' => array(
-      'https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v1.0.9/js/main.b294abb7.js' => array(
+      'https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v1.0.10/js/main.d41fc3fe.js' => array(
         'type' => 'external',
         'scope' => 'footer',
       ),
     ),
     'css' => array(
-      'https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v1.0.9/css/main.cf6a58ce.css' => array(
+      'https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v1.0.10/css/main.cf6a58ce.css' => array(
         'type' => 'external',
       ),
     ),


### PR DESCRIPTION
[PL-10](https://palantir.atlassian.net/browse/PL-10)

## Ticket Description
Add "Show results for empty search" (`empty-search-results` or something) option to federated-search-react and create the corresponding config option search_api_federated_solr D8 and D7 branches. This should be a boolean that defaults to false.
Reconfigure react components to behave based on that config.

## PR Description
This PR adds the `show_empty_search_results` config to the **D7** drupal settings form for federated search

## To Test (from federated-search-react repo)
1. Dependent on https://github.com/palantirnet/federated-search-react/pull/25