### PR TITLE
Fix regression that popped up between #50 and #51

### DIFF
--- a/src/SearchApiFederatedSolrUrls.php
+++ b/src/SearchApiFederatedSolrUrls.php
@@ -49,10 +49,10 @@ class SearchApiFederatedSolrUrls extends SearchApiAbstractAlterCallback {
     foreach ($items as &$item) {
       $url = $this->index->datasource()->getItemUrl($item);
       if (!$url) {
-        $item->search_api_urls = NULL;
+        $item->urls = NULL;
         continue;
       }
-      $item->search_api_urls = [url($url['path'], array('absolute' => TRUE) + $url['options'])];
+      $item->urls = [url($url['path'], array('absolute' => TRUE) + $url['options'])];
     }
   }
 


### PR DESCRIPTION
Between #50 and #51 somehow the non-domain field name was added to a new function and not changed (and nobody noticed because we didn't have a domain site to test). Fixed.