### PR TITLE
PL-50: Allow enabling the filter without any fields configured.

### DIFF
--- a/src/SearchApiFederatedSolrField.php
+++ b/src/SearchApiFederatedSolrField.php
@@ -46,68 +46,71 @@ class SearchApiFederatedSolrField extends SearchApiAbstractAlterCallback {
       '#suffix' => '</div>',
     ];
 
-    foreach ($this->options['fields'] as $key => $field) {
-      $item = [
-        '#type' => 'fieldset',
-        '#title' => !isset($field['is_new']) ?
-          t("@label (%machine_name)", ['@label' => $field['label'], '%machine_name' => $field['machine_name']]) : t('New field'),
-        '#collapsible' => TRUE,
-        '#collapsed' => !isset($field['is_new']),
-      ];
-      $item['label'] = [
-        '#type' => 'textfield',
-        '#title' => t('Label'),
-        '#default_value' => $field['label'],
-        '#maxlength' => 255,
-      ];
-      $item['machine_name'] = [
-        '#type' => 'textfield',
-        '#title' => t('Machine Name'),
-        '#required' => TRUE,
-        '#default_value' => $field['machine_name'],
-        '#maxlength' => 32,
-      ];
-      $item['type'] = [
-        '#type' => 'select',
-        '#title' => t('Data type'),
-        '#options' => search_api_default_field_types(),
-        '#default_value' => (TRUE === isset($field['type'])) ? $field['type'] : 'string',
-        '#required' => TRUE,
-        '#description' => t('Data type to save field as'),
-      ];
-      $item['bundle'] = [
-        '#type' => 'fieldset',
-        '#title' => t('Value to index for each type'),
-        '#description' => t('Enter a token or plain text in the field for each type of indexed item.'),
-        '#collapsible' => TRUE,
-      ];
+    if (isset($this->options['fields'])) {
 
-      $entity_info = entity_get_info($this->index->getEntityType());
-      foreach ($entity_info['bundles'] as $bundle => $bundle_info) {
-        $item['bundle'][$bundle] = [
-          '#type' => 'textfield',
-          '#title' => t('@label (%machine_name)', ['@label' => $bundle_info['label'], '%machine_name' => $bundle]),
-          '#default_value' => $field['bundle'][$bundle],
+      foreach ($this->options['fields'] as $key => $field) {
+        $item = [
+          '#type' => 'fieldset',
+          '#title' => !isset($field['is_new']) ?
+            t("@label (%machine_name)", ['@label' => $field['label'], '%machine_name' => $field['machine_name']]) : t('New field'),
+          '#collapsible' => TRUE,
+          '#collapsed' => !isset($field['is_new']),
         ];
-      }
+        $item['label'] = [
+          '#type' => 'textfield',
+          '#title' => t('Label'),
+          '#default_value' => $field['label'],
+          '#maxlength' => 255,
+        ];
+        $item['machine_name'] = [
+          '#type' => 'textfield',
+          '#title' => t('Machine Name'),
+          '#required' => TRUE,
+          '#default_value' => $field['machine_name'],
+          '#maxlength' => 32,
+        ];
+        $item['type'] = [
+          '#type' => 'select',
+          '#title' => t('Data type'),
+          '#options' => search_api_default_field_types(),
+          '#default_value' => (TRUE === isset($field['type'])) ? $field['type'] : 'string',
+          '#required' => TRUE,
+          '#description' => t('Data type to save field as'),
+        ];
+        $item['bundle'] = [
+          '#type' => 'fieldset',
+          '#title' => t('Value to index for each type'),
+          '#description' => t('Enter a token or plain text in the field for each type of indexed item.'),
+          '#collapsible' => TRUE,
+        ];
 
-      $item['actions'] = array(
-        '#type' => 'actions',
-        'remove' => array(
-          '#type' => 'submit',
-          '#value' => t('Remove field'),
-          '#submit' => array('_search_api_federated_solr_add_field_submit'),
-          '#limit_validation_errors' => array(),
-          '#name' => '_search_api_federated_solr_remove_' . $key,
-          '#ajax' => array(
-            'callback' => '_search_api_federated_solr_add_field_ajax',
-            'wrapper' => 'search-api-federated-solr-add-field-settings',
+        $entity_info = entity_get_info($this->index->getEntityType());
+        foreach ($entity_info['bundles'] as $bundle => $bundle_info) {
+          $item['bundle'][$bundle] = [
+            '#type' => 'textfield',
+            '#title' => t('@label (%machine_name)', ['@label' => $bundle_info['label'], '%machine_name' => $bundle]),
+            '#default_value' => $field['bundle'][$bundle],
+          ];
+        }
+
+        $item['actions'] = array(
+          '#type' => 'actions',
+          'remove' => array(
+            '#type' => 'submit',
+            '#value' => t('Remove field'),
+            '#submit' => array('_search_api_federated_solr_add_field_submit'),
+            '#limit_validation_errors' => array(),
+            '#name' => '_search_api_federated_solr_remove_' . $key,
+            '#ajax' => array(
+              'callback' => '_search_api_federated_solr_add_field_ajax',
+              'wrapper' => 'search-api-federated-solr-add-field-settings',
+            ),
           ),
-        ),
-      );
+        );
 
 
-      $form['fields'][$key] = $item;
+        $form['fields'][$key] = $item;
+      }
     }
 
     $form['tokens'] = [
@@ -144,10 +147,12 @@ class SearchApiFederatedSolrField extends SearchApiAbstractAlterCallback {
   public function configurationFormValidate(array $form, array &$values, array &$form_state) {
     parent::configurationFormValidate($form, $values, $form_state);
 
-    foreach ($values['fields'] as $key => $field) {
-      if (preg_match('/^[0-9]|[^a-z0-9_]/i', $field['machine_name'])) {
-        $name = "callbacks][federated_field][settings][fields][{$key}][machine_name";
-        form_set_error($name, 'Federated field machine names must consist of alphanumeric or underscore characters only and not start with a digit.');
+    if (isset($values['fields'])) {
+      foreach ($values['fields'] as $key => $field) {
+        if (preg_match('/^[0-9]|[^a-z0-9_]/i', $field['machine_name'])) {
+          $name = "callbacks][federated_field][settings][fields][{$key}][machine_name";
+          form_set_error($name, 'Federated field machine names must consist of alphanumeric or underscore characters only and not start with a digit.');
+        }
       }
     }
   }
@@ -156,10 +161,13 @@ class SearchApiFederatedSolrField extends SearchApiAbstractAlterCallback {
    * {@inheritdoc}
    */
   public function configurationFormSubmit(array $form, array &$values, array &$form_state) {
-    foreach ($values['fields'] as $key => $field) {
-      if ($key != $field['machine_name']) {
-        unset($values['fields'][$key]);
-        $values['fields'][$field['machine_name']] = $field;
+
+    if (isset($values['fields'])) {
+      foreach ($values['fields'] as $key => $field) {
+        if ($key != $field['machine_name']) {
+          unset($values['fields'][$key]);
+          $values['fields'][$field['machine_name']] = $field;
+        }
       }
     }
 


### PR DESCRIPTION
Before notices would be thrown when the form was saved / loaded with the filter enabled but not configured.

Test:
- Install the modules
- Create an index
- Enable the `Federated Field` filter, see https://www.drupal.org/docs/7/modules/search-api-federated-solr/search-api-federated-solr-module/intro-install-configure
- Save the form
- Note that there are no notices
- In the filter list, add a field to the filter
- Save the form
- Note that there are no notices