### PR TITLE
Use drupal vendor and stable release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,6 @@
     "drupal/core": "^8.0",
     "drupal/search_api_solr": "^1.2",
     "drupal/token": "^1.1",
-    "palantirnet/search_api_field_map": "dev-master"
+    "drupal/search_api_field_map": "^1.0"
   }
 }


### PR DESCRIPTION
When trying to install search_api_federated_solr on my local using Composer, I was receiving:

```
  Problem 1
    - drupal/search_api_federated_solr 1.0.0 requires palantirnet/search_api_field_map dev-master -> no matching package found.
    - drupal/search_api_federated_solr 1.x-dev requires palantirnet/search_api_field_map dev-master -> no matching package found.
    - Installation request for drupal/search_api_federated_solr ^1.0 -> satisfiable by drupal/search_api_federated_solr[1.x-dev, 1.0.0].
```