### PR TITLE
Fix yaml format of search_api_federated_solr.libraries.yml

### DIFF
--- a/search_api_federated_solr.libraries.yml
+++ b/search_api_federated_solr.libraries.yml
@@ -2,9 +2,10 @@ search:
   version: 1.x
   css:
     theme:
-      https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v1.0.10/css/main.cf6a58ce.css: { type: external, minified: true }
+      https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v1.0.10/css/main.cf6a58ce.css:
+        type: external
+        minified: true
   js:
-    https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v1.0.10/js/main.d41fc3fe.js: {
-      preprocess: false,
-      minified: true,
-    }
+    https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v1.0.10/js/main.d41fc3fe.js:
+      preprocess: false
+      minified: true


### PR DESCRIPTION
I was receiving an error at /search-app about invalid yml syntax. This patch fixed it so that I could view the page again.