### PR TITLE
Issue #3045632 by alonaoneill: Dependency namespacing in .info.yml file

### DIFF
--- a/search_api_federated_solr.info.yml
+++ b/search_api_federated_solr.info.yml
@@ -4,7 +4,7 @@ description: Allows indexing multiple Drupal sites into a single Solr search ind
 core: 8.x
 package: Search
 dependencies:
-  - search_api_field_map
-  - search_api_solr
-  - token
-  - field
+  - drupal:field
+  - search_api_field_map:search_api_field_map
+  - search_api_solr:search_api_solr
+  - token:token


### PR DESCRIPTION
Should be applied to both 8.x-2.x and 8.x.1.x.

https://www.drupal.org/project/search_api_federated_solr/issues/3045632