### PR TITLE
Issue #3045721: Support relative URLs for autocomplete endpoint

### DIFF
--- a/src/Plugin/Block/FederatedSearchPageFormBlock.php
+++ b/src/Plugin/Block/FederatedSearchPageFormBlock.php
@@ -8,6 +8,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\search_api_federated_solr\Utility\Helpers;
+use Drupal\Component\Utility\UrlHelper;
 
 /**
  * Provides a "Federated Search Page Form" block.
@@ -161,7 +162,7 @@ class FederatedSearchPageFormBlock extends BlockBase implements BlockPluginInter
     ];
 
     $form['autocomplete']['direct']['autocomplete_url'] = [
-      '#type' => 'url',
+      '#type' => 'textfield',
       '#title' => $this->t('Endpoint URL'),
       '#default_value' => isset($config['autocomplete']['directUrl']) ? $config['autocomplete']['directUrl'] : '',
       '#maxlength' => 2048,
@@ -318,6 +319,29 @@ class FederatedSearchPageFormBlock extends BlockBase implements BlockPluginInter
     ];
 
     return $form;
+  }
+
+  /**
+   * Validates that the provided autocomplete endpoint path is a valid relative or
+   * absolute URL.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   */
+  public function blockValidate($form, FormStateInterface $form_state) {
+    $key = ['autocomplete', 'direct', 'autocomplete_url'];
+    $path = $form_state->getValue($key);
+    if ($path) {
+      if ($path !== '' && !UrlHelper::isValid($path, FALSE)) {
+        $element['#parents'] = $key;
+        $form_state
+          ->setError($element, t('The URL %url is not valid.', array(
+          '%url' => $path,
+        )));
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Adds support for relative autocomplete endpoint URLs by changing the field type to `textfield` and using `UrlHelper::isValid()` to validate the input.

### Testing

- Checkout this branch in `src/search_api_federated_solr` on the [Federated Search Demo](https://github.com/palantirnet/federated-search-demo).
- Add the search block to a region on the D8 demo site.
- Go to the block configuration, enable autocomplete, and disable the proxy.
- Try entering and saving different values for the "Endpoint URL" (use relative, absolute, and invalid URLs).
- Notice valid relative and absolute URLs are accepted and invalid URLs are still rejected with an error message for the field.