### PR TITLE
add #39 to 7.x-2.x umhs-28: use canonical URL for results

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ When changes to [federated-search-react](https://github.com/palantirnet/federate
 
 ## More information
 
-Full documentation for this module is in the [handbook on Drupal.org](https://www.drupal.org/docs/7/modules/search-api-federated-solr/search-api-federated-solr-module)
+Full documentation for this module is available in the [handbook on Drupal.org](https://www.drupal.org/docs/7/modules/search-api-federated-solr/search-api-federated-solr-module)
 
 * [How to use this module](https://www.drupal.org/docs/7/modules/search-api-federated-solr/search-api-federated-solr-module/intro-install-configure)
 * [How to configure a Search API Index for federated search](https://www.drupal.org/docs/8/modules/search-api-federated-solr/federated-search-schema)

--- a/search_api_federated_solr.info
+++ b/search_api_federated_solr.info
@@ -9,6 +9,7 @@ dependencies[] = search_api_solr
 dependencies[] = token
 
 files[] = search-api_federated_solr.module
+files[] = src/SearchApiFederatedSolrCanonicalUrl.php
 files[] = src/SearchApiFederatedSolrField.php
 files[] = src/SearchApiFederatedSolrTerms.php
 files[] = src/SearchApiFederatedSolrRemap.php

--- a/search_api_federated_solr.module
+++ b/search_api_federated_solr.module
@@ -69,6 +69,11 @@ function search_api_federated_solr_search_api_alter_callback_info() {
     'description' => t('The links to the node on all available sites. This can be useful if indexing multiple sites with a single search index.'),
     'class' => 'SearchApiFederatedSolrUrls',
   );
+  $callbacks['canonical_url'] = array(
+    'name' => t('Canonical URL'),
+    'description' => t('Preferred URL for this content.'),
+    'class' => 'SearchApiFederatedSolrCanonicalUrl',
+  );
   $callbacks['federated_field'] = array(
     'name' => t('Federated Field'),
     'description' => t('A token or free text field that can be customized per-bundle.'),


### PR DESCRIPTION
Add the canonical URL Search API index data alteration to the 2.x branch. (This was previously added to 7.x-1.x in #39.)