### PR TITLE
Umhs 27 restrict d7

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,28 @@ In order to display results from the Solr index:
 1. Configure the application route and settings at `/admin/config/search/federated-search-settings`
 1. Set permissions for `Use Federated Search` and `Administer Federated Search` for the proper roles.
 1. Optional: Configure default fields for queries.  The default query field for search queries made through the proxy provided by this module is the `rendered_item` field.  To set a different value for the default query fields there are two options:
-    1. Set `$config['search_api_federated_solr_proxy_query_fields']` to an array of _Fulltext_ field machine names (i.e. `['rendered_item', 'full_text_title']`) from your search index in `settings.php`.
+    1. Set `$conf['search_api_federated_solr_proxy_query_fields']` to an array of _Fulltext_ field machine names (i.e. `['rendered_item', 'full_text_title']`) from your search index in `settings.php`.
         - This method will not work if you disable the proxy that this module provides for querying your solr backend in the search app or block autocomplete settings
-        - By default, the proxy will validate the field names to ensure that they are full text and that they exist on the index for this site.  Then it will translate the index field name into its solr field name counterpart.  If you need to disable this validation + transformation (for example to search fields on a D8 site index whose machine names are different than the D7 site counterpart), set `$config['search_api_federated_solr_proxy_validate_query_fields_against_schema']` to `FALSE`.  Then you must supply the _solr field names_.  To determine what these field names are on your D7 site, use the drush command `drush sapifs-f`, which will output a table with index field names and their solr field name counterparts.
+        - By default, the proxy will validate the field names to ensure that they are full text and that they exist on the index for this site.  Then it will translate the index field name into its solr field name counterpart.  If you need to disable this validation + transformation (for example to search fields on a D8 site index whose machine names are different than the D7 site counterpart), set `$conf['search_api_federated_solr_proxy_validate_query_fields_against_schema']` to `FALSE`.  Then you must supply the _solr field names_.  To determine what these field names are on your D7 site, use the drush command `drush sapifs-f`, which will output a table with index field names and their solr field name counterparts.
     1. Configure that Search API server to set default query fields for your default [Request Handler](https://lucene.apache.org/solr/guide/6_6/requesthandlers-and-searchcomponents-in-solrconfig.html#RequestHandlersandSearchComponentsinSolrConfig-SearchHandlers). (See [example](https://github.com/palantirnet/federated-search-demo/blob/master/conf/solr/drupal8/custom/solr-conf/4.x/solrconfig_extra.xml#L94) in Federated Search Demo site Solr server config)
+1. Optional: Configure a list of sites that you wish to search from this instance. You can restrict the list of sites to search by adding configuration to your `settings.php` file.
+    1. Set `$conf['search_api_federated_solr_site_list']` to an array of site name for your sites. This can normally be left blank if you wish to search all sites in your installed cluster. The array should normally include all sites in your cluster and be in the format:
+       ```
+       $conf['search_api_federated_solr_site_list'] = [
+         'Site name 1',
+         'Site name 2',
+         'Site name 3',
+         'Site name 4',
+       ];
+       ```
+    1. Configure the list of `Sites that may be searched from this instance` through the module configuration page. You may optionally set this in `settings.php` as well, by setting the `$config['search_api_federated_solr_allowed_sites']` variable:
+      ```
+       $conf['search_api_federated_solr_allowed_sites'] = [
+         'Site name 1',
+         'Site name 2',
+       ];
+       ```
+       This example would only allow two of the four sites to be searched from this site. This configuration must be added to every site individually.
 1. Optional: [Theme the ReactJS search app](https://www.drupal.org/docs/7/modules/search-api-federated-solr/search-api-federated-solr-module/theming-the-reactjs-search)
 1. Optional: Add the federated search page form block to your site theme
 
@@ -24,7 +42,7 @@ In order to display results from the Solr index:
 
 To see debug information when using the proxy for your search queries, set `$conf['search_api_federated_solr_proxy_debug_query']` to `TRUE` in your settings.php.
 
-Then user your browsers developer tools to inspect  network traffic.  When your site makes a search query through the proxy, inspect the response for this request and you should now see a `debug` object added to the response object. 
+Then user your browsers developer tools to inspect  network traffic.  When your site makes a search query through the proxy, inspect the response for this request and you should now see a `debug` object added to the response object.
 
 *Note: we recommend leaving this set to `FALSE` for production environments, as it could have an impact on performance.*
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ In order to display results from the Solr index:
          'Site name 4',
        ];
        ```
+
     1. Configure the list of `Sites that may be searched from this instance` through the module configuration page. You may optionally set this in `settings.php` as well, by setting the `$config['search_api_federated_solr_allowed_sites']` variable:
       ```
        $conf['search_api_federated_solr_allowed_sites'] = [
@@ -34,6 +35,7 @@ In order to display results from the Solr index:
          'Site name 2',
        ];
        ```
+
        This example would only allow two of the four sites to be searched from this site. This configuration must be added to every site individually.
 1. Optional: [Theme the ReactJS search app](https://www.drupal.org/docs/7/modules/search-api-federated-solr/search-api-federated-solr-module/theming-the-reactjs-search)
 1. Optional: Add the federated search page form block to your site theme
@@ -55,14 +57,7 @@ Search API Federated Solr requires the following modules:
 
 The module also relies on the [Federated Search React](https://github.com/palantirnet/federated-search-react) application, which is referenced as an external Drupal library.
 
-Apache Solr versions `4.5.1` and `5.x` have been used with this module and it is likely that newer versions will also work.
-
-## Updating the bundled React application
-
-When changes to [federated-search-react](https://github.com/palantirnet/federated-search-react/) are made they'll need to be pulled into this module. To do so:
-
-1. [Publish a release](https://github.com/palantirnet/federated-search-react#publishing-releases) of Federated Search React.
-2. Update `search_api_federated_solr_library()` in `search_api_federated_solr.module` to reference the new release. Note: You'll need to edit the version number and the hash of both the CSS and JS files.
+Apache Solr versions `4.5.1`, `5.x`, and `6.x` have been used with this module and it is likely that newer versions will also work.
 
 ## More information
 
@@ -72,3 +67,16 @@ Full documentation for this module is available in the [handbook on Drupal.org](
 * [How to configure a Search API Index for federated search](https://www.drupal.org/docs/8/modules/search-api-federated-solr/federated-search-schema)
 * [How to theme the ReactJS search app](https://www.drupal.org/docs/7/modules/search-api-federated-solr/search-api-federated-solr-module/theming-the-reactjs-search)
 * [Setting up the search page and block](https://www.drupal.org/docs/7/modules/search-api-federated-solr/search-api-federated-solr-module/setting-up-the-search-page)
+
+MAINTAINERS
+-----------
+
+Current maintainers:
+ * Matthew Carmichael (mcarmichael21) - https://www.drupal.org/u/mcarmichael21
+ * Jes Constantine (jesconstantine) - https://www.drupal.org/u/jesconstantine
+ * Malak Desai (MalakDesai) - https://www.drupal.org/u/malakdesai
+ * Byron Duval (byrond) -- https://www.drupal.org/u/byrond
+ * Ken Rickard (agentrickard) - https://www.drupal.org/u/agentrickard
+
+This project has been sponsored by:
+ * Palantir.net - https://palantir.net

--- a/js/search_api_federated_solr_autocomplete.js
+++ b/js/search_api_federated_solr_autocomplete.js
@@ -138,7 +138,10 @@
             var fq = $(input).attr("name") + ':("' + $(input).val() + '")';
             defaultParams += "&fq=" + encodeURI(fq);
           });
-
+          // Set defaultParams from configuration.
+          if (options.sm_site_name) {
+            defaultParams += "&fq=sm_site_name:" + options.sm_site_name;
+          }
           // Set the text default query.
           var urlWithDefaultParams = options.url + defaultParams;
 

--- a/search_api_federated_solr.admin.inc
+++ b/search_api_federated_solr.admin.inc
@@ -36,6 +36,13 @@ function search_api_federated_solr_admin($form, &$form_state) {
     '#description' => t('The path for the search app (Default: "search-app").'),
   ];
 
+  $form['setup']['search_api_federated_solr_page_title'] = [
+    '#type' => 'textfield',
+    '#title' => t('Search results page title'),
+    '#default_value' => variable_get('search_api_federated_solr_page_title', ''),
+    '#description' => t('The title that will live in the header tag of the search results page (leave empty to hide completely).'),
+  ];
+
   $form['setup']['search_api_federated_solr_search_index'] = [
     '#type' => 'select',
     '#title' => t('Search API index'),

--- a/search_api_federated_solr.admin.inc
+++ b/search_api_federated_solr.admin.inc
@@ -202,8 +202,8 @@ function search_api_federated_solr_admin($form, &$form_state) {
       '#options' => $sites,
       '#title' => t('Sites that may be searched from this instance'),
       '#default_value' => variable_get('search_api_federated_solr_allowed_sites', []),
-      '#description' => t('When at least one option is checked, only search results from these sites will be shown as options in the search app\'s "Site name" facet. Default searches will only query the selected sites. If no options are checked, all sites in the network will be available. If no options are visible, you will need to configure your site list in settings.php. See <a href=":url">the help page for information</a>',
-        [':url' => '/admin/help/search_api_federated_solr']),
+      '#description' => t('When at least one option is checked, only search results from these sites will be shown as options in the search app\'s "Site name" facet. Default searches will only query the selected sites. If no options are checked, all sites in the network will be available. If no options are visible, you will need to configure your site list in settings.php. See <a href="!url">the help page for information</a>',
+        ['!url' => '/admin/help/search_api_federated_solr']),
       '#states' => [
         'visible' => [
           ':input[name="site_name_property"]' => [

--- a/search_api_federated_solr.admin.inc
+++ b/search_api_federated_solr.admin.inc
@@ -192,6 +192,27 @@ function search_api_federated_solr_admin($form, &$form_state) {
     ],
   ];
 
+    $site_list = variable_get('search_api_federated_solr_site_list');
+    $sites = [];
+    foreach ($site_list as $site) {
+      $sites[$site] = $site;
+    }
+    $form['search_form_values']['defaults']['search_api_federated_solr_allowed_sites'] = [
+      '#type' => 'checkboxes',
+      '#options' => $sites,
+      '#title' => t('Sites that may be searched from this instance'),
+      '#default_value' => variable_get('search_api_federated_solr_allowed_sites', []),
+      '#description' => t('When at least one option is checked, only search results from these sites will be shown as options in the search app\'s "Site name" facet. Default searches will only query the selected sites. If no options are checked, all sites in the network will be available. If no options are visible, you will need to configure your site list in settings.php. See <a href=":url">the help page for information</a>',
+        [':url' => '/admin/help/search_api_federated_solr']),
+      '#states' => [
+        'visible' => [
+          ':input[name="site_name_property"]' => [
+            'value' => "true",
+          ],
+        ],
+      ],
+    ];
+
   if (!empty(variable_get('search_api_federated_solr_search_index'))) {
     $index = variable_get('search_api_federated_solr_search_index');
     if (isset($settings[$index])) {

--- a/search_api_federated_solr.module
+++ b/search_api_federated_solr.module
@@ -645,13 +645,13 @@ function search_api_federated_solr_library() {
     'title' => 'Federated Search App',
     'version' => variable_get('css_js_query_string', '0'),
     'js' => array(
-      'https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v2.1.2/js/main.f36175e5.js' => array(
+      'https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v2.1.3/js/main.3dcebe99.js' => array(
         'scope' => 'footer',
         'type' => 'external',
       ),
     ),
     'css' => array(
-      'https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v2.1.2/css/main.ec684809.css' => array(
+      'https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v2.1.3/css/main.ec684809.css' => array(
         'type' => 'external',
       ),
     ),

--- a/search_api_federated_solr.module
+++ b/search_api_federated_solr.module
@@ -14,10 +14,13 @@ function search_api_federated_solr_help($path, $arg) {
   switch ($path) {
     // Main module help for the search_api_federated_solr module.
     case 'admin/help#search_api_federated_solr':
-    $output = '';
-    $output .= '<h3>' . t('About') . '</h3>';
-    $output .= '<p>' . t('Allows indexing into a single Solr search index.') . '</p>';
-    return $output;
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('Allows indexing into a single Solr search index.') . '</p>';
+      $output .= '<p>' . t('This help text uses Markdown. Install the <a href="@markdown">Markdown module</a> or <a href="@readme">view it online</a> for easier reading', ['@markdown' => 'https://www.drupal.org/project/markdown', '@readme' => 'https://git.drupalcode.org/project/search_api_federated_solr/tree/7.x-2.x']) . '</p>';
+      $text = file_get_contents(dirname(__FILE__) . '/README.md');
+      $output .= search_api_federated_solr_parse_help($text);
+      return $output;
   }
 }
 
@@ -973,4 +976,25 @@ function search_api_federated_solr_get_site_name() {
   }
 
   return $site_name;
+}
+
+/**
+ * Simplified display of help text without markdown module.
+ *
+ * @param $text
+ *   The help text markdown.
+ *
+ * @return HTML
+ */
+function search_api_federated_solr_parse_help($text) {
+  $find = "```\n\n";
+  $replace = '</pre>';
+  $text = str_replace($find, $replace, $text);
+  $find = "```";
+  $replace = '<pre>';
+  $text = str_replace($find, $replace, $text);
+  $find = ["\n"];
+  $replace = ['<br />'];
+  $text = str_replace($find, $replace, $text);
+  return $text;
 }

--- a/search_api_federated_solr.module
+++ b/search_api_federated_solr.module
@@ -405,6 +405,18 @@ function search_api_federated_solr_search_block_form($form, &$form_state) {
     drupal_add_css(drupal_get_path('module', 'search_api_federated_solr') . '/css/search_api_federated_solr_autocomplete.css', 'file');
   }
 
+  // Send site name as qs param if app is configured to load w/default site.
+  if (variable_get('search_api_federated_solr_set_search_site')) {
+    $site_name = search_api_federated_solr_get_site_name();
+    if ($site_name) {
+      $form['sm_site_name'] = [
+        '#type' => 'hidden',
+        '#name' => 'sm_site_name',
+        '#default_value' => $site_name,
+      ];
+    }
+  }
+
   $form['submit'] = array(
     '#type' => 'submit',
     '#value' => t('Search'),

--- a/search_api_federated_solr.module
+++ b/search_api_federated_solr.module
@@ -921,3 +921,33 @@ function search_api_federated_solr_get_endpoint_url($proxy_is_disabled, $direct_
 
   return $endpoint_url;
 }
+
+/**
+ * Returns the active site name value.
+ *
+ * @return string
+ */
+function search_api_federated_solr_get_site_name() {
+  $site_name = variable_get('site_name');
+  $search_index = variable_get('search_api_federated_solr_search_index');
+  // Get the index entity.
+  /** @var \SearchApiIndex $index */
+  $index = search_api_index_load($search_index);
+  // The site name can be configured as part of the filter.
+  // Get the proper variable.
+  if (!empty($index->options['data_alter_callbacks']['site_name']['settings']['site_name'])) {
+    $site_name = $index->options['data_alter_callbacks']['site_name']['settings']['site_name'];
+  }
+  // Handle domain access.
+  elseif (function_exists('domain_get_domain') && !empty($index->options['data_alter_callbacks']['site_name']['settings'])) {
+    $domain = domain_get_domain();
+    if (!empty($index->options['data_alter_callbacks']['site_name']['settings']['domain'][$domain['machine_name']])) {
+      $site_name = $index->options['data_alter_callbacks']['site_name']['settings']['domain'][$domain['machine_name']];
+    }
+    else {
+      $site_name = isset($domain['sitename']) ? $domain['sitename'] : variable_get('site_name');
+    }
+  }
+
+  return $site_name;
+}

--- a/search_api_federated_solr.module
+++ b/search_api_federated_solr.module
@@ -440,6 +440,7 @@ function search_api_federated_solr_block_variables() {
       $autocomplete[$value] = variable_get($value);
     }
   }
+
   return search_api_federated_solr_map_variables($autocomplete);
 }
 
@@ -826,6 +827,16 @@ function search_api_federated_solr_map_variables($variables) {
   $title_text = $variables['search_api_federated_solr_autocomplete_block_' . $mode . '_title_text'] ? $variables['search_api_federated_solr_autocomplete_block_' . $mode . '_title_text'] : "What are you looking for?";
   $autocomplete['result']['titleText'] = $title_text;
   $autocomplete['result']['hideDirectionsText'] = $variables['search_api_federated_solr_autocomplete_block_' . $mode . '_hide_directions_text'];
+
+  // Set the constraints for allowed sites.
+  if ($allowed_sites = variable_get('search_api_federated_solr_allowed_sites')) {
+    $list = [];
+    $sites = array_keys(array_filter($allowed_sites));
+    foreach ($sites as $site) {
+      $list[] = '"' . $site . '"';
+    }
+    $autocomplete['sm_site_name'] = '(' . implode(' OR ', $list) . ')';
+  }
 
   return $autocomplete;
 }

--- a/search_api_federated_solr.module
+++ b/search_api_federated_solr.module
@@ -728,6 +728,8 @@ function search_api_federated_solr_variables() {
     'search_api_federated_solr_hide_date',
     'search_api_federated_solr_hide_terms',
     'search_api_federated_solr_set_search_site',
+    'search_api_federated_solr_allowed_sites',
+    'search_api_federated_solr_site_list',
     'search_api_federated_solr_autocomplete_is_enabled',
     'search_api_federated_solr_autocomplete_is_append_wildcard',
     'search_api_federated_solr_autocomplete_disable_query_proxy',

--- a/search_api_federated_solr.page.inc
+++ b/search_api_federated_solr.page.inc
@@ -119,11 +119,20 @@ function search_api_federated_solr_config_json() {
     $federated_search_app_config['paginationButtons'] = $pagination_buttons;
   }
 
-  /** Not implemented yet in D7.
   // OPTIONAL: The rendered title of the search page.
-  if ($page_title = $config->get('page_title')) {
+  if ($page_title = variable_get('search_api_federated_solr_page_title')) {
     $federated_search_app_config['pageTitle'] = $page_title;
-  }*/
+  }
+
+  // OPTIONAL: Pre-select this site.
+  if ($site_seach = variable_get('search_api_federated_solr_set_search_site')) {
+    $federated_search_app_config['siteSearch'] = search_api_federated_solr_get_site_name();
+  }
+
+  // OPTIONAL: The allowed list of sites for the search.
+  if ($allowed_sites = variable_get('search_api_federated_solr_allowed_sites')) {
+    $federated_search_app_config['sm_site_name'] = array_keys(array_filter($allowed_sites));
+  }
 
   $federated_search_app_config['autocomplete'] = FALSE;
   if ($autocomplete_is_enabled = variable_get('search_api_federated_solr_autocomplete_is_enabled')) {

--- a/search_api_federated_solr.proxy.inc
+++ b/search_api_federated_solr.proxy.inc
@@ -70,6 +70,41 @@ function search_api_federated_solr_proxy() {
     $query_fields = array_values($query_fields_map);
   }
 
+  // Determine if we have issued a site_name query, and filter it as
+  // required by the site list settings. Note that if we set a default
+  // site name value, it will be passed to the proxy as an 'fq' value.
+  $ignore_default = FALSE;
+  if (!empty($params) && is_array($params)) {
+    // Account for strings passed by the query.
+    if (isset($params['fq'])) {
+      if (is_string($params['fq'])) {
+        $params['fq'] = [$params['fq']];
+      }
+    }
+    foreach ($params['fq'] as $key => $value) {
+      if (substr_count($value, 'sm_site_name') > 0) {
+        $fq = urldecode($value);
+        unset($params['fq'][$key]);
+        $params['fq'][] = $fq;
+        $ignore_default = TRUE;
+      }
+    }
+  }
+
+  // If site search is restricted, enforce it here.
+  if (!$ignore_default) {
+    // Get the list of allowed sites.
+    if ($allowed_sites = variable_get('search_api_federated_solr_allowed_sites')) {
+      $site_list = array_keys(array_filter($allowed_sites));
+    }
+    if (!empty($site_list)) {
+      foreach ($site_list as $name) {
+        $values[] = '"'. $name .'"';
+      }
+      $params['fq'][] = 'sm_site_name:(' . implode(' OR ', $values) . ')';
+    }
+  }
+
   // If site search is restricted, enforce it here.
   if (variable_get('search_api_federated_solr_set_search_site', 0)) {
     if (!empty($params['fq']) && !is_array($params['fq'])) {

--- a/search_api_federated_solr.proxy.inc
+++ b/search_api_federated_solr.proxy.inc
@@ -71,9 +71,7 @@ function search_api_federated_solr_proxy() {
   }
 
   // If site search is restricted, enforce it here.
-  $restrict_site = variable_get('search_api_federated_solr_set_search_site', 0)
-                && variable_get('search_api_federated_solr_hide_site_name', 0);
-  if ($restrict_site) {
+  if (variable_get('search_api_federated_solr_set_search_site', 0)) {
     if (!empty($params['fq']) && !is_array($params['fq'])) {
       $params['fq'] = array($params['fq']);
     }
@@ -85,24 +83,7 @@ function search_api_federated_solr_proxy() {
         unset($params['fq'][$id]);
       }
     }
-    // The site name can be configured as part of the filter.
-    // Get the proper variable.
-    if (!empty($index->options['data_alter_callbacks']['site_name']['settings']['site_name'])) {
-      $site_name = $index->options['data_alter_callbacks']['site_name']['settings']['site_name'];
-    }
-    // Handle domain access.
-    elseif (function_exists('domain_get_domain') && !empty($index->options['data_alter_callbacks']['site_name']['settings'])) {
-      $domain = domain_get_domain();
-      if (!empty($index->options['data_alter_callbacks']['site_name']['settings']['domain'][$domain['machine_name']])) {
-        $site_name = $index->options['data_alter_callbacks']['site_name']['settings']['domain'][$domain['machine_name']];
-      }
-      else {
-        $site_name = isset($domain['sitename']) ? $domain['sitename'] : variable_get('site_name');
-      }
-    }
-    else {
-      $site_name = variable_get('site_name');
-    }
+    $site_name = search_api_federated_solr_get_site_name();
     $params['fq'][] = 'sm_site_name:("' . $site_name . '")';
   }
 

--- a/search_api_federated_solr.proxy.inc
+++ b/search_api_federated_solr.proxy.inc
@@ -81,6 +81,9 @@ function search_api_federated_solr_proxy() {
         $params['fq'] = [$params['fq']];
       }
     }
+    else {
+      $params['fq'] = [];
+    }
     foreach ($params['fq'] as $key => $value) {
       if (substr_count($value, 'sm_site_name') > 0) {
         $fq = urldecode($value);


### PR DESCRIPTION
This is the Drupal 7 version of #96.

Handles https://palantir.atlassian.net/browse/UMHS-27

This PR depends on the work in https://github.com/palantirnet/federated-search-react/pull/46

###  Testing Instuctions

* In the `federated-search-react` repository, checkout and test branch `UMHS-27-limit-sites` according to the instructions in https://github.com/palantirnet/federated-search-react/pull/46
* In that repo, run `yarn build`
* Copy the new CSS and JS assets to the module directory here.
* Edit `search_api_federated_solr_library()` to use the new CSS and JS files.
* Clear cache

Now you can test things.

* On the default (non-domain access) Drupal 7 site, add configuration to `settings.php` to enable restricting the list of sites. 

       ```
       $conf['search_api_federated_solr.search_app_site_list'] = [
         'Site name 1',
         'Site name 2',
         'Site name 3',
         'Site name 4',
       ];
       ```

See README.md for more information.

* Go to configure the app at http://d7.fs-demo.local/admin/config/search/federated-search-settings
* Note the new field under `Search Results Page > Facets & Filters` which is ` Sites that may be searched from this instance`
* That field should contain the site list that you put in `settings.php.`
* Configure that field to show only two sites.
* Set the default `empty` search to show results.
* Go to http://d7.fs-demo.local/search-app?search=
* Confirm that only two sites appear in the Site Name filter and that both are selected.
* Confirm that you can use the Site Name filters as expected.
* Confirm that changing the list of allowed sites changes the behavior of search.
* Confirm that setting the list of allowed sites to empty (no selections) show all sites and selects none by default.
* Profit.

