### PR TITLE
FS-28 update css override documentation

### DIFF
--- a/docs/assets/search_theme_override.css
+++ b/docs/assets/search_theme_override.css
@@ -1,335 +1,265 @@
 /**
  * Custom search override styles.
  */
-
+/*
+ * Begin search override styles
+ Apply all styles to be scoped globally within the Federated Search app inside the #fs-root ID.
+ */
 /**
  * Search filters
  */
 /* The container for the search filters */
-aside {
-  background-color: #f6f6f6;
-}
+aside.fs-aside {
+  background-color: #f6f6f6; }
 
 /* Search filters */
-/* Mobile search button / Desktop sidebar title */
-/* Search filters clear button */
-.search-filters__trigger,
-.search-filters__title {
-  color: #333;
-  font-size: 1.1em;
-  line-height: 1.46667em;
-}
-.search-filters__reset {
-  background-color: #e5e5e5;
-  border: 1px solid #ccc;
-  border-radius: 3px;
-  font-size: .8em;
-  line-height: 1.83333em;
-}
-.search-filters__reset:active,
-.search-filters__reset:hover,
-.search-filters__reset:focus {
-  background-color: #d8d8d8;
-  border-color: #b5b5b5;
-  text-decoration: underline;
-}
+.fs-search-filters {
+  /* Mobile search button / Desktop sidebar title */
+  /* Search filters clear button */ }
+  .fs-search-filters__trigger, .fs-search-filters__title {
+    color: #333;
+    font-size: 1.1em;
+    line-height: 1.46667em; }
+  .fs-search-filters__reset {
+    background-color: #e5e5e5;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    font-size: .8em;
+    line-height: 1.83333em; }
+    .fs-search-filters__reset:active, .fs-search-filters__reset:hover, .fs-search-filters__reset:focus {
+      background-color: #d8d8d8;
+      border-color: #b5b5b5;
+      text-decoration: underline; }
 
 /* Search filter accordion */
-.search-accordion {
+.fs-search-accordion {
   color: #333;
-  /* Top level accordion links */
-}
-.search-accordion__title {
-  color: #0d57aa;
-  border-bottom: 1px solid #e5e5e5;
-  font-size: .8em;
-}
-.search-accordion__title:active,
-.search-accordion__title:hover {
-  color: #002a5b;
-  background-color: #e5e5e5;
-  border-color: #b5b5b5;
-  text-decoration: none;
-}
-.search-accordion__title:focus,
-.search-accordion__title.js-search-accordion-open {
-  color: #0d57aa;
-  border-color: #b5b5b5;
-  text-decoration: none;
-}
+  /* Top level accordion links */ }
+  .fs-search-accordion__title {
+    color: #0d57aa;
+    border-bottom: 1px solid #e5e5e5;
+    font-size: .8em; }
+    .fs-search-accordion__title:active, .fs-search-accordion__title:hover {
+      color: #002a5b;
+      background-color: #e5e5e5;
+      border-color: #b5b5b5;
+      text-decoration: none; }
+    .fs-search-accordion__title:focus, .fs-search-accordion__title.js-search-accordion-open {
+      color: #0d57aa;
+      border-color: #b5b5b5;
+      text-decoration: none; }
 
 /**
  * Search form
  */
-.search-form__label {
+.fs-search-form__label {
   color: #222;
   font-size: .8em;
-  line-height: 1.83333em;
-}
+  line-height: 1.83333em; }
 
-.search-form__input {
+.fs-search-form__input {
   border-radius: 3px 0 0 3px;
-  border: 1px solid #e5e5e5;
-}
-.search-form__input:focus {
-  border: 1px solid #555;
-  outline: 0;
-}
+  border: 1px solid #e5e5e5; }
+  .fs-search-form__input:focus {
+    border: 1px solid #555;
+    outline: 0; }
 
-.search-form__submit {
+.fs-search-form__submit {
   background-color: #ffcb05;
   border-radius: 0 3px 3px 0;
   border: 1px solid #e5e5e5;
-  border-left: 0;
-}
-.search-form__submit svg {
-  fill: #222;
-}
-.search-form__submit:active,
-.search-form__submit:hover,
-.search-form__submit:focus {
-  background-color: #f4bb06;
-  border-color: #e5e5e5;
-}
-.search-form__submit:active svg,
-.search-form__submit:hover svg,
-.search-form__submit:focus svg {
-  fill: #222;
-}
+  border-left: 0; }
+  .fs-search-form__submit svg {
+    fill: #222; }
+  .fs-search-form__submit:active, .fs-search-form__submit:hover, .fs-search-form__submit:focus {
+    background-color: #f4bb06;
+    border-color: #e5e5e5; }
+    .fs-search-form__submit:active svg, .fs-search-form__submit:hover svg, .fs-search-form__submit:focus svg {
+      fill: #222; }
 
 /**
  * Applied Filters
  */
-.applied-filters__filter {
+.fs-applied-filters__filter {
   border-bottom: solid 2px #ffcb05;
   font-size: .8em;
   line-height: 1.46667em;
-  padding-bottom: .29333em;
-}
+  padding-bottom: .29333em; }
 
 /**
  * Search results list
  */
-/* Search results eyebrow (i.e. the content type). */
-/* Search results metadata (i.e. the site + date) */
-/* Search result snippet text */
-/* highlighted text in snippet */
-.search-results__heading a {
-  background-color: transparent;
-  color: #0d57aa;
-  text-decoration: none;
-  border-bottom: 2px dashed #0d57aa;
-}
-.search-results__heading a:active,
-.search-results__heading a:hover {
-  outline-width: 0;
-  color: #002a5b;
-  background-color: #e5e5e5;
-  border-bottom: 2px solid #002a5b;
-}
-.search-results__label {
-  color: #555;
-  font-size: .8em;
-}
-.search-results__meta {
-  color: #555;
-  font-size: .8em;
-  line-height: 1.46667em;
-}
-.search-results__teaser {
-  font-size: 18px;
-  line-height: 1.3;
-}
-.search-results em {
-  font-weight: 700;
-  background-color: rgba(255, 242, 192, 0.85);
-}
+.fs-search-results {
+  /* Search results eyebrow (i.e. the content type). */
+  /* Search results metadata (i.e. the site + date) */
+  /* Search result snippet text */
+  /* highlighted text in snippet */ }
+  .fs-search-results__heading a {
+    background-color: transparent;
+    color: #0d57aa;
+    text-decoration: none;
+    border-bottom: 2px dashed #0d57aa; }
+    .fs-search-results__heading a:active, .fs-search-results__heading a:hover {
+      outline-width: 0;
+      color: #002a5b;
+      background-color: #e5e5e5;
+      border-bottom: 2px solid #002a5b; }
+  .fs-search-results__label {
+    color: #555;
+    font-size: .8em; }
+  .fs-search-results__meta {
+    color: #555;
+    font-size: .8em;
+    line-height: 1.46667em; }
+  .fs-search-results__teaser {
+    font-size: 18px;
+    line-height: 1.3; }
+  .fs-search-results em {
+    font-weight: 700;
+    background-color: rgba(255, 242, 192, 0.85); }
 
 /**
  * Pagination component
  */
-.search-pager {
+.fs-search-pager {
   background-color: transparent;
   /** pagination component **/
   /** inactive page links **/
-  /** active page link **/
-}
-.search-pager__items {
-  border-radius: 3px;
-  background-color: #eff0f1;
-}
-@media (min-width: 450px) {
-  .search-pager__items {
-    background-color: transparent;
-  }
-}
-@media (min-width: 450px) {
-  .search-pager__item a {
-    background-color: #ffcb05;
+  /** active page link **/ }
+  .fs-search-pager__items {
     border-radius: 3px;
-  }
-}
-.search-pager__item a:hover,
-.search-pager__item a:active {
-  text-decoration: underline;
-  color: #00274c;
-  background-color: #ffcb05;
-}
-@media (min-width: 450px) {
-  .search-pager__item a:hover,
-  .search-pager__item a:active {
-    background-color: #f4bb06;
-  }
-}
-.search-pager__item a:hover svg,
-.search-pager__item a:active svg {
-  fill: #00274c;
-}
-@media (min-width: 450px) {
-  .search-pager__item.is-active a {
-    background-color: #0d57aa;
-    color: #fff;
-  }
-  .search-pager__item.is-active a:hover,
-  .search-pager__item.is-active a:active {
-    background-color: #002a5b;
-  }
-}
+    background-color: #eff0f1; }
+    @media (min-width: 450px) {
+      .fs-search-pager__items {
+        background-color: transparent; } }
+  @media (min-width: 450px) {
+    .fs-search-pager__item a {
+      background-color: #ffcb05;
+      border-radius: 3px; } }
+  .fs-search-pager__item a:hover, .fs-search-pager__item a:active {
+    text-decoration: underline;
+    color: #00274c;
+    background-color: #ffcb05; }
+    @media (min-width: 450px) {
+      .fs-search-pager__item a:hover, .fs-search-pager__item a:active {
+        background-color: #f4bb06; } }
+    .fs-search-pager__item a:hover svg, .fs-search-pager__item a:active svg {
+      fill: #00274c; }
+  @media (min-width: 450px) {
+    .fs-search-pager__item.is-active a {
+      background-color: #0d57aa;
+      color: #fff; }
+      .fs-search-pager__item.is-active a:hover, .fs-search-pager__item.is-active a:active {
+        background-color: #002a5b; } }
 
 /**
  DatePicker widget
  */
 .PresetDateRangePicker_button {
   border: 2px solid #4696f1;
-  color: #4696f1;
-}
+  color: #4696f1; }
 
 .PresetDateRangePicker_button__selected {
   color: #fff;
-  background: #4696f1;
-}
+  background: #4696f1; }
 
 .DayPickerKeyboardShortcuts_show__bottomRight {
   border-top: 26px solid transparent;
-  border-right: 33px solid #0d57aa;
-}
+  border-right: 33px solid #0d57aa; }
 
 .DayPickerKeyboardShortcuts_show__bottomRight:hover {
-  border-right: 33px solid #083363;
-}
+  border-right: 33px solid #083363; }
 
 .DayPickerKeyboardShortcuts_show__topRight {
   border-bottom: 26px solid transparent;
-  border-right: 33px solid #0d57aa;
-}
+  border-right: 33px solid #0d57aa; }
 
 .DayPickerKeyboardShortcuts_show__topRight:hover {
-  border-right: 33px solid #083363;
-}
+  border-right: 33px solid #083363; }
 
 .DayPickerKeyboardShortcuts_show__topLeft {
   border-bottom: 26px solid transparent;
-  border-left: 33px solid #4696f1;
-}
+  border-left: 33px solid #4696f1; }
 
 .DayPickerKeyboardShortcuts_show__topLeft:hover {
-  border-left: 33px solid #00274c;
-}
+  border-left: 33px solid #00274c; }
 
 .CalendarDay__selected_span {
   background: #ebf4fe;
   border: 1px solid #75b1f4;
-  color: #0d57aa;
-}
+  color: #0d57aa; }
 
 .CalendarDay__selected_span:active,
 .CalendarDay__selected_span:hover {
   background: #d8d8d8;
   border: 1px solid #b5b5b5;
-  color: #fff;
-}
+  color: #fff; }
 
 .CalendarDay__last_in_range {
-  border-right: #4696f1;
-}
+  border-right: #4696f1; }
 
 .CalendarDay__selected,
 .CalendarDay__selected:active,
 .CalendarDay__selected:hover {
   background: #0d57aa;
   border: 1px solid #0d57aa;
-  color: #fff;
-}
+  color: #fff; }
 
 .CalendarDay__hovered_span,
 .CalendarDay__hovered_span:hover {
   background: #ebf4fe;
   border: 1px solid #75b1f4;
-  color: #0d57aa;
-}
+  color: #0d57aa; }
 
 .CalendarDay__hovered_span:active {
   background: #ebf4fe;
   border: 1px solid #75b1f4;
-  color: #0d57aa;
-}
+  color: #0d57aa; }
 
 .DateInput_input__focused {
-  border-bottom: 2px solid #0d57aa;
-}
+  border-bottom: 2px solid #0d57aa; }
 
 .CalendarDay__highlighted_calendar {
   background: #fff2c0;
-  color: #555;
-}
+  color: #555; }
 
 .CalendarDay__highlighted_calendar:active,
 .CalendarDay__highlighted_calendar:hover {
   background: #ffcb05;
-  color: #555;
-}
+  color: #555; }
 
 .DateInput_input::placeholder {
-  color: #555;
-}
+  color: #555; }
 
 .DayPicker_weekHeader_li {
-  display: inline-block !important;
-}
+  display: inline-block !important; }
 
 .DateRangePickerInput_clearDates_default:focus,
 .DateRangePickerInput_clearDates_default:hover {
-  border-radius: 0;
-}
+  border-radius: 0; }
 
 @media only screen and (max-width: 1350px) and (min-width: 901px) {
   .DateInput_input__small {
     font-size: 12px;
     line-height: 18px;
-    padding: 8px 4px 6px;
-  }
+    padding: 8px 4px 6px; }
   .DateInput__small {
-    width: 70px;
-  }
-}
+    width: 70px; } }
 
 .KeyboardShortcutRow_keyContainer {
   display: inline-block;
   white-space: nowrap;
   text-align: right;
-  margin-right: 6px;
-}
+  margin-right: 6px; }
 
 .KeyboardShortcutRow_key {
   font-family: monospace;
   font-size: 12px;
   text-transform: uppercase;
   background: #f6f6f6;
-  padding: 2px 6px;
-}
+  padding: 2px 6px; }
 
 .KeyboardShortcutRow_action {
   display: inline;
   word-break: break-word;
-  margin-left: 8px;
-}
+  margin-left: 8px; }

--- a/docs/assets/search_theme_override.css
+++ b/docs/assets/search_theme_override.css
@@ -20,22 +20,25 @@ aside.fs-aside {
   /* Mobile search button / Desktop sidebar title */
   /* Search filters clear button */
 }
-.fs-search-filters__trigger, .fs-search-filters__title {
+.fs-search-filters__trigger,
+.fs-search-filters__title {
   color: #333;
   font-size: 1.1em;
   line-height: 1.46667em;
 }
 .fs-search-filters__reset {
-  background-color: #e5e5e5;
   border: 1px solid #ccc;
   border-radius: 3px;
-  font-size: .8em;
+  background-color: #e5e5e5;
+  font-size: 0.8em;
   line-height: 1.83333em;
 }
-.fs-search-filters__reset:active, .fs-search-filters__reset:hover, .fs-search-filters__reset:focus {
-  background-color: #d8d8d8;
-  border-color: #b5b5b5;
+.fs-search-filters__reset:active,
+.fs-search-filters__reset:hover,
+.fs-search-filters__reset:focus {
   text-decoration: underline;
+  border-color: #b5b5b5;
+  background-color: #d8d8d8;
 }
 /* Search filter accordion */
 .fs-search-accordion {
@@ -45,55 +48,61 @@ aside.fs-aside {
 .fs-search-accordion__title {
   color: #0d57aa;
   border-bottom: 1px solid #e5e5e5;
-  font-size: .8em;
+  font-size: 0.8em;
 }
-.fs-search-accordion__title:active, .fs-search-accordion__title:hover {
-  color: #002a5b;
-  background-color: #e5e5e5;
-  border-color: #b5b5b5;
+.fs-search-accordion__title:active,
+.fs-search-accordion__title:hover {
   text-decoration: none;
+  color: #002a5b;
+  border-color: #b5b5b5;
+  background-color: #e5e5e5;
 }
-.fs-search-accordion__title:focus, .fs-search-accordion__title.js-search-accordion-open {
+.fs-search-accordion__title:focus,
+.fs-search-accordion__title.js-search-accordion-open {
+  text-decoration: none;
   color: #0d57aa;
   border-color: #b5b5b5;
-  text-decoration: none;
 }
 /*** Search form*/
 .fs-search-form__label {
   color: #222;
-  font-size: .8em;
+  font-size: 0.8em;
   line-height: 1.83333em;
 }
 .fs-search-form__input {
-  border-radius: 3px 0 0 3px;
   border: 1px solid #e5e5e5;
+  border-radius: 3px 0 0 3px;
 }
 .fs-search-form__input:focus {
   border: 1px solid #555;
   outline: 0;
 }
 .fs-search-form__submit {
-  background-color: #ffcb05;
-  border-radius: 0 3px 3px 0;
   border: 1px solid #e5e5e5;
   border-left: 0;
+  border-radius: 0 3px 3px 0;
+  background-color: #ffcb05;
 }
 .fs-search-form__submit svg {
   fill: #222;
 }
-.fs-search-form__submit:active, .fs-search-form__submit:hover, .fs-search-form__submit:focus {
-  background-color: #f4bb06;
+.fs-search-form__submit:active,
+.fs-search-form__submit:hover,
+.fs-search-form__submit:focus {
   border-color: #e5e5e5;
+  background-color: #f4bb06;
 }
-.fs-search-form__submit:active svg, .fs-search-form__submit:hover svg, .fs-search-form__submit:focus svg {
+.fs-search-form__submit:active svg,
+.fs-search-form__submit:hover svg,
+.fs-search-form__submit:focus svg {
   fill: #222;
 }
 /*** Applied Filters*/
 .fs-applied-filters__filter {
+  padding-bottom: 0.29333em;
   border-bottom: solid 2px #ffcb05;
-  font-size: .8em;
+  font-size: 0.8em;
   line-height: 1.46667em;
-  padding-bottom: .29333em;
 }
 /*** Search results list*/
 .fs-search-results {
@@ -103,24 +112,25 @@ aside.fs-aside {
   /* highlighted text in snippet */
 }
 .fs-search-results__heading a {
-  background-color: transparent;
-  color: #0d57aa;
   text-decoration: none;
+  color: #0d57aa;
   border-bottom: 2px dashed #0d57aa;
+  background-color: transparent;
 }
-.fs-search-results__heading a:active, .fs-search-results__heading a:hover {
-  outline-width: 0;
+.fs-search-results__heading a:active,
+.fs-search-results__heading a:hover {
   color: #002a5b;
-  background-color: #e5e5e5;
   border-bottom: 2px solid #002a5b;
+  outline-width: 0;
+  background-color: #e5e5e5;
 }
 .fs-search-results__label {
   color: #555;
-  font-size: .8em;
+  font-size: 0.8em;
 }
 .fs-search-results__meta {
   color: #555;
-  font-size: .8em;
+  font-size: 0.8em;
   line-height: 1.46667em;
 }
 .fs-search-results__teaser {
@@ -128,8 +138,8 @@ aside.fs-aside {
   line-height: 1.3;
 }
 .fs-search-results em {
-  font-weight: 700;
   background-color: rgba(255, 242, 192, 0.85);
+  font-weight: 700;
 }
 /*** Pagination component*/
 .fs-search-pager {
@@ -149,36 +159,40 @@ aside.fs-aside {
 }
 @media (min-width: 450px) {
   .fs-search-pager__item a {
-    background-color: #ffcb05;
     border-radius: 3px;
+    background-color: #ffcb05;
   }
 }
-.fs-search-pager__item a:hover, .fs-search-pager__item a:active {
+.fs-search-pager__item a:hover,
+.fs-search-pager__item a:active {
   text-decoration: underline;
   color: #00274c;
   background-color: #ffcb05;
 }
 @media (min-width: 450px) {
-  .fs-search-pager__item a:hover, .fs-search-pager__item a:active {
+  .fs-search-pager__item a:hover,
+  .fs-search-pager__item a:active {
     background-color: #f4bb06;
   }
 }
-.fs-search-pager__item a:hover svg, .fs-search-pager__item a:active svg {
+.fs-search-pager__item a:hover svg,
+.fs-search-pager__item a:active svg {
   fill: #00274c;
 }
 @media (min-width: 450px) {
   .fs-search-pager__item.is-active a {
-    background-color: #0d57aa;
     color: #fff;
+    background-color: #0d57aa;
   }
-  .fs-search-pager__item.is-active a:hover, .fs-search-pager__item.is-active a:active {
+  .fs-search-pager__item.is-active a:hover,
+  .fs-search-pager__item.is-active a:active {
     background-color: #002a5b;
   }
 }
 /**DatePicker widget*/
 .PresetDateRangePicker_button {
-  border: 2px solid #4696f1;
   color: #4696f1;
+  border: 2px solid #4696f1;
 }
 .PresetDateRangePicker_button__selected {
   color: #fff;
@@ -192,8 +206,8 @@ aside.fs-aside {
   border-right: 33px solid #083363;
 }
 .DayPickerKeyboardShortcuts_show__topRight {
-  border-bottom: 26px solid transparent;
   border-right: 33px solid #0d57aa;
+  border-bottom: 26px solid transparent;
 }
 .DayPickerKeyboardShortcuts_show__topRight:hover {
   border-right: 33px solid #083363;
@@ -206,43 +220,48 @@ aside.fs-aside {
   border-left: 33px solid #00274c;
 }
 .CalendarDay__selected_span {
-  background: #ebf4fe;
-  border: 1px solid #75b1f4;
   color: #0d57aa;
+  border: 1px solid #75b1f4;
+  background: #ebf4fe;
 }
-.CalendarDay__selected_span:active,.CalendarDay__selected_span:hover {
-  background: #d8d8d8;
-  border: 1px solid #b5b5b5;
+.CalendarDay__selected_span:active,
+.CalendarDay__selected_span:hover {
   color: #fff;
+  border: 1px solid #b5b5b5;
+  background: #d8d8d8;
 }
 .CalendarDay__last_in_range {
   border-right: #4696f1;
 }
-.CalendarDay__selected,.CalendarDay__selected:active,.CalendarDay__selected:hover {
-  background: #0d57aa;
-  border: 1px solid #0d57aa;
+.CalendarDay__selected,
+.CalendarDay__selected:active,
+.CalendarDay__selected:hover {
   color: #fff;
+  border: 1px solid #0d57aa;
+  background: #0d57aa;
 }
-.CalendarDay__hovered_span,.CalendarDay__hovered_span:hover {
-  background: #ebf4fe;
-  border: 1px solid #75b1f4;
+.CalendarDay__hovered_span,
+.CalendarDay__hovered_span:hover {
   color: #0d57aa;
+  border: 1px solid #75b1f4;
+  background: #ebf4fe;
 }
 .CalendarDay__hovered_span:active {
-  background: #ebf4fe;
-  border: 1px solid #75b1f4;
   color: #0d57aa;
+  border: 1px solid #75b1f4;
+  background: #ebf4fe;
 }
 .DateInput_input__focused {
   border-bottom: 2px solid #0d57aa;
 }
 .CalendarDay__highlighted_calendar {
+  color: #555;
   background: #fff2c0;
-  color: #555;
 }
-.CalendarDay__highlighted_calendar:active,.CalendarDay__highlighted_calendar:hover {
-  background: #ffcb05;
+.CalendarDay__highlighted_calendar:active,
+.CalendarDay__highlighted_calendar:hover {
   color: #555;
+  background: #ffcb05;
 }
 .DateInput_input::placeholder {
   color: #555;
@@ -250,14 +269,15 @@ aside.fs-aside {
 .DayPicker_weekHeader_li {
   display: inline-block !important;
 }
-.DateRangePickerInput_clearDates_default:focus,.DateRangePickerInput_clearDates_default:hover {
+.DateRangePickerInput_clearDates_default:focus,
+.DateRangePickerInput_clearDates_default:hover {
   border-radius: 0;
 }
 @media only screen and (max-width: 1350px) and (min-width: 901px) {
   .DateInput_input__small {
+    padding: 8px 4px 6px;
     font-size: 12px;
     line-height: 18px;
-    padding: 8px 4px 6px;
   }
   .DateInput__small {
     width: 70px;
@@ -265,19 +285,19 @@ aside.fs-aside {
 }
 .KeyboardShortcutRow_keyContainer {
   display: inline-block;
-  white-space: nowrap;
-  text-align: right;
   margin-right: 6px;
+  text-align: right;
+  white-space: nowrap;
 }
 .KeyboardShortcutRow_key {
-  font-family: monospace;
-  font-size: 12px;
+  padding: 2px 6px;
   text-transform: uppercase;
   background: #f6f6f6;
-  padding: 2px 6px;
+  font-family: monospace;
+  font-size: 12px;
 }
 .KeyboardShortcutRow_action {
   display: inline;
-  word-break: break-word;
   margin-left: 8px;
+  word-break: break-word;
 }

--- a/docs/assets/search_theme_override.css
+++ b/docs/assets/search_theme_override.css
@@ -1,265 +1,283 @@
 /**
  * Custom search override styles.
- */
+*/
+
 /*
  * Begin search override styles
- Apply all styles to be scoped globally within the Federated Search app inside the #fs-root ID.
+ * Apply all styles to be scoped globally within the Federated Search app inside the #fs-root ID.
  */
+
 /**
  * Search filters
  */
+
 /* The container for the search filters */
 aside.fs-aside {
-  background-color: #f6f6f6; }
-
+  background-color: #f6f6f6;
+}
 /* Search filters */
 .fs-search-filters {
   /* Mobile search button / Desktop sidebar title */
-  /* Search filters clear button */ }
-  .fs-search-filters__trigger, .fs-search-filters__title {
-    color: #333;
-    font-size: 1.1em;
-    line-height: 1.46667em; }
-  .fs-search-filters__reset {
-    background-color: #e5e5e5;
-    border: 1px solid #ccc;
-    border-radius: 3px;
-    font-size: .8em;
-    line-height: 1.83333em; }
-    .fs-search-filters__reset:active, .fs-search-filters__reset:hover, .fs-search-filters__reset:focus {
-      background-color: #d8d8d8;
-      border-color: #b5b5b5;
-      text-decoration: underline; }
-
+  /* Search filters clear button */
+}
+.fs-search-filters__trigger, .fs-search-filters__title {
+  color: #333;
+  font-size: 1.1em;
+  line-height: 1.46667em;
+}
+.fs-search-filters__reset {
+  background-color: #e5e5e5;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  font-size: .8em;
+  line-height: 1.83333em;
+}
+.fs-search-filters__reset:active, .fs-search-filters__reset:hover, .fs-search-filters__reset:focus {
+  background-color: #d8d8d8;
+  border-color: #b5b5b5;
+  text-decoration: underline;
+}
 /* Search filter accordion */
 .fs-search-accordion {
   color: #333;
-  /* Top level accordion links */ }
-  .fs-search-accordion__title {
-    color: #0d57aa;
-    border-bottom: 1px solid #e5e5e5;
-    font-size: .8em; }
-    .fs-search-accordion__title:active, .fs-search-accordion__title:hover {
-      color: #002a5b;
-      background-color: #e5e5e5;
-      border-color: #b5b5b5;
-      text-decoration: none; }
-    .fs-search-accordion__title:focus, .fs-search-accordion__title.js-search-accordion-open {
-      color: #0d57aa;
-      border-color: #b5b5b5;
-      text-decoration: none; }
-
-/**
- * Search form
- */
+  /* Top level accordion links */
+}
+.fs-search-accordion__title {
+  color: #0d57aa;
+  border-bottom: 1px solid #e5e5e5;
+  font-size: .8em;
+}
+.fs-search-accordion__title:active, .fs-search-accordion__title:hover {
+  color: #002a5b;
+  background-color: #e5e5e5;
+  border-color: #b5b5b5;
+  text-decoration: none;
+}
+.fs-search-accordion__title:focus, .fs-search-accordion__title.js-search-accordion-open {
+  color: #0d57aa;
+  border-color: #b5b5b5;
+  text-decoration: none;
+}
+/*** Search form*/
 .fs-search-form__label {
   color: #222;
   font-size: .8em;
-  line-height: 1.83333em; }
-
+  line-height: 1.83333em;
+}
 .fs-search-form__input {
   border-radius: 3px 0 0 3px;
-  border: 1px solid #e5e5e5; }
-  .fs-search-form__input:focus {
-    border: 1px solid #555;
-    outline: 0; }
-
+  border: 1px solid #e5e5e5;
+}
+.fs-search-form__input:focus {
+  border: 1px solid #555;
+  outline: 0;
+}
 .fs-search-form__submit {
   background-color: #ffcb05;
   border-radius: 0 3px 3px 0;
   border: 1px solid #e5e5e5;
-  border-left: 0; }
-  .fs-search-form__submit svg {
-    fill: #222; }
-  .fs-search-form__submit:active, .fs-search-form__submit:hover, .fs-search-form__submit:focus {
-    background-color: #f4bb06;
-    border-color: #e5e5e5; }
-    .fs-search-form__submit:active svg, .fs-search-form__submit:hover svg, .fs-search-form__submit:focus svg {
-      fill: #222; }
-
-/**
- * Applied Filters
- */
+  border-left: 0;
+}
+.fs-search-form__submit svg {
+  fill: #222;
+}
+.fs-search-form__submit:active, .fs-search-form__submit:hover, .fs-search-form__submit:focus {
+  background-color: #f4bb06;
+  border-color: #e5e5e5;
+}
+.fs-search-form__submit:active svg, .fs-search-form__submit:hover svg, .fs-search-form__submit:focus svg {
+  fill: #222;
+}
+/*** Applied Filters*/
 .fs-applied-filters__filter {
   border-bottom: solid 2px #ffcb05;
   font-size: .8em;
   line-height: 1.46667em;
-  padding-bottom: .29333em; }
-
-/**
- * Search results list
- */
+  padding-bottom: .29333em;
+}
+/*** Search results list*/
 .fs-search-results {
   /* Search results eyebrow (i.e. the content type). */
   /* Search results metadata (i.e. the site + date) */
   /* Search result snippet text */
-  /* highlighted text in snippet */ }
-  .fs-search-results__heading a {
-    background-color: transparent;
-    color: #0d57aa;
-    text-decoration: none;
-    border-bottom: 2px dashed #0d57aa; }
-    .fs-search-results__heading a:active, .fs-search-results__heading a:hover {
-      outline-width: 0;
-      color: #002a5b;
-      background-color: #e5e5e5;
-      border-bottom: 2px solid #002a5b; }
-  .fs-search-results__label {
-    color: #555;
-    font-size: .8em; }
-  .fs-search-results__meta {
-    color: #555;
-    font-size: .8em;
-    line-height: 1.46667em; }
-  .fs-search-results__teaser {
-    font-size: 18px;
-    line-height: 1.3; }
-  .fs-search-results em {
-    font-weight: 700;
-    background-color: rgba(255, 242, 192, 0.85); }
-
-/**
- * Pagination component
- */
+  /* highlighted text in snippet */
+}
+.fs-search-results__heading a {
+  background-color: transparent;
+  color: #0d57aa;
+  text-decoration: none;
+  border-bottom: 2px dashed #0d57aa;
+}
+.fs-search-results__heading a:active, .fs-search-results__heading a:hover {
+  outline-width: 0;
+  color: #002a5b;
+  background-color: #e5e5e5;
+  border-bottom: 2px solid #002a5b;
+}
+.fs-search-results__label {
+  color: #555;
+  font-size: .8em;
+}
+.fs-search-results__meta {
+  color: #555;
+  font-size: .8em;
+  line-height: 1.46667em;
+}
+.fs-search-results__teaser {
+  font-size: 18px;
+  line-height: 1.3;
+}
+.fs-search-results em {
+  font-weight: 700;
+  background-color: rgba(255, 242, 192, 0.85);
+}
+/*** Pagination component*/
 .fs-search-pager {
   background-color: transparent;
   /** pagination component **/
   /** inactive page links **/
-  /** active page link **/ }
+  /** active page link **/
+}
+.fs-search-pager__items {
+  border-radius: 3px;
+  background-color: #eff0f1;
+}
+@media (min-width: 450px) {
   .fs-search-pager__items {
+    background-color: transparent;
+  }
+}
+@media (min-width: 450px) {
+  .fs-search-pager__item a {
+    background-color: #ffcb05;
     border-radius: 3px;
-    background-color: #eff0f1; }
-    @media (min-width: 450px) {
-      .fs-search-pager__items {
-        background-color: transparent; } }
-  @media (min-width: 450px) {
-    .fs-search-pager__item a {
-      background-color: #ffcb05;
-      border-radius: 3px; } }
+  }
+}
+.fs-search-pager__item a:hover, .fs-search-pager__item a:active {
+  text-decoration: underline;
+  color: #00274c;
+  background-color: #ffcb05;
+}
+@media (min-width: 450px) {
   .fs-search-pager__item a:hover, .fs-search-pager__item a:active {
-    text-decoration: underline;
-    color: #00274c;
-    background-color: #ffcb05; }
-    @media (min-width: 450px) {
-      .fs-search-pager__item a:hover, .fs-search-pager__item a:active {
-        background-color: #f4bb06; } }
-    .fs-search-pager__item a:hover svg, .fs-search-pager__item a:active svg {
-      fill: #00274c; }
-  @media (min-width: 450px) {
-    .fs-search-pager__item.is-active a {
-      background-color: #0d57aa;
-      color: #fff; }
-      .fs-search-pager__item.is-active a:hover, .fs-search-pager__item.is-active a:active {
-        background-color: #002a5b; } }
-
-/**
- DatePicker widget
- */
+    background-color: #f4bb06;
+  }
+}
+.fs-search-pager__item a:hover svg, .fs-search-pager__item a:active svg {
+  fill: #00274c;
+}
+@media (min-width: 450px) {
+  .fs-search-pager__item.is-active a {
+    background-color: #0d57aa;
+    color: #fff;
+  }
+  .fs-search-pager__item.is-active a:hover, .fs-search-pager__item.is-active a:active {
+    background-color: #002a5b;
+  }
+}
+/**DatePicker widget*/
 .PresetDateRangePicker_button {
   border: 2px solid #4696f1;
-  color: #4696f1; }
-
+  color: #4696f1;
+}
 .PresetDateRangePicker_button__selected {
   color: #fff;
-  background: #4696f1; }
-
+  background: #4696f1;
+}
 .DayPickerKeyboardShortcuts_show__bottomRight {
   border-top: 26px solid transparent;
-  border-right: 33px solid #0d57aa; }
-
+  border-right: 33px solid #0d57aa;
+}
 .DayPickerKeyboardShortcuts_show__bottomRight:hover {
-  border-right: 33px solid #083363; }
-
+  border-right: 33px solid #083363;
+}
 .DayPickerKeyboardShortcuts_show__topRight {
   border-bottom: 26px solid transparent;
-  border-right: 33px solid #0d57aa; }
-
+  border-right: 33px solid #0d57aa;
+}
 .DayPickerKeyboardShortcuts_show__topRight:hover {
-  border-right: 33px solid #083363; }
-
+  border-right: 33px solid #083363;
+}
 .DayPickerKeyboardShortcuts_show__topLeft {
   border-bottom: 26px solid transparent;
-  border-left: 33px solid #4696f1; }
-
+  border-left: 33px solid #4696f1;
+}
 .DayPickerKeyboardShortcuts_show__topLeft:hover {
-  border-left: 33px solid #00274c; }
-
+  border-left: 33px solid #00274c;
+}
 .CalendarDay__selected_span {
   background: #ebf4fe;
   border: 1px solid #75b1f4;
-  color: #0d57aa; }
-
-.CalendarDay__selected_span:active,
-.CalendarDay__selected_span:hover {
+  color: #0d57aa;
+}
+.CalendarDay__selected_span:active,.CalendarDay__selected_span:hover {
   background: #d8d8d8;
   border: 1px solid #b5b5b5;
-  color: #fff; }
-
+  color: #fff;
+}
 .CalendarDay__last_in_range {
-  border-right: #4696f1; }
-
-.CalendarDay__selected,
-.CalendarDay__selected:active,
-.CalendarDay__selected:hover {
+  border-right: #4696f1;
+}
+.CalendarDay__selected,.CalendarDay__selected:active,.CalendarDay__selected:hover {
   background: #0d57aa;
   border: 1px solid #0d57aa;
-  color: #fff; }
-
-.CalendarDay__hovered_span,
-.CalendarDay__hovered_span:hover {
+  color: #fff;
+}
+.CalendarDay__hovered_span,.CalendarDay__hovered_span:hover {
   background: #ebf4fe;
   border: 1px solid #75b1f4;
-  color: #0d57aa; }
-
+  color: #0d57aa;
+}
 .CalendarDay__hovered_span:active {
   background: #ebf4fe;
   border: 1px solid #75b1f4;
-  color: #0d57aa; }
-
+  color: #0d57aa;
+}
 .DateInput_input__focused {
-  border-bottom: 2px solid #0d57aa; }
-
+  border-bottom: 2px solid #0d57aa;
+}
 .CalendarDay__highlighted_calendar {
   background: #fff2c0;
-  color: #555; }
-
-.CalendarDay__highlighted_calendar:active,
-.CalendarDay__highlighted_calendar:hover {
+  color: #555;
+}
+.CalendarDay__highlighted_calendar:active,.CalendarDay__highlighted_calendar:hover {
   background: #ffcb05;
-  color: #555; }
-
+  color: #555;
+}
 .DateInput_input::placeholder {
-  color: #555; }
-
+  color: #555;
+}
 .DayPicker_weekHeader_li {
-  display: inline-block !important; }
-
-.DateRangePickerInput_clearDates_default:focus,
-.DateRangePickerInput_clearDates_default:hover {
-  border-radius: 0; }
-
+  display: inline-block !important;
+}
+.DateRangePickerInput_clearDates_default:focus,.DateRangePickerInput_clearDates_default:hover {
+  border-radius: 0;
+}
 @media only screen and (max-width: 1350px) and (min-width: 901px) {
   .DateInput_input__small {
     font-size: 12px;
     line-height: 18px;
-    padding: 8px 4px 6px; }
+    padding: 8px 4px 6px;
+  }
   .DateInput__small {
-    width: 70px; } }
-
+    width: 70px;
+  }
+}
 .KeyboardShortcutRow_keyContainer {
   display: inline-block;
   white-space: nowrap;
   text-align: right;
-  margin-right: 6px; }
-
+  margin-right: 6px;
+}
 .KeyboardShortcutRow_key {
   font-family: monospace;
   font-size: 12px;
   text-transform: uppercase;
   background: #f6f6f6;
-  padding: 2px 6px; }
-
+  padding: 2px 6px;
+}
 .KeyboardShortcutRow_action {
   display: inline;
   word-break: break-word;
-  margin-left: 8px; }
+  margin-left: 8px;
+}

--- a/docs/assets/search_theme_override.scss
+++ b/docs/assets/search_theme_override.scss
@@ -34,7 +34,7 @@ $c-tertiary: $gray-medium;
 $c-tertiary-dark: $gray-dark;
 $c-tertiary-light: $gray-light;
 
-// Use above sass variables to define defaults in normalize.scss
+// Use above sass variables to define defaults for the app.
 $text-color: $gray-dark;
 $background-color: $white;
 $link-color: $c-primary-light;
@@ -48,9 +48,10 @@ $bp3: 1100px;
 
 /*
  * Begin search override styles
+ Apply all styles to be scoped globally within the Federated Search app inside the #fs-root ID.
  */
 
-html {
+#fs-root {
   //font-family: $helvetica-neue;
 }
 
@@ -59,12 +60,12 @@ html {
  */
 
 /* The container for the search filters */
-aside {
+aside.fs-aside {
   background-color: $c-bg-gray;
 }
 
 /* Search filters */
-.search-filters {
+.fs-search-filters {
   /* Mobile search button / Desktop sidebar title */
   &__trigger,
   &__title {
@@ -92,7 +93,7 @@ aside {
 }
 
 /* Search filter accordion */
-.search-accordion {
+.fs-search-accordion {
   color: $gray-dark;
 
   /* Top level accordion links */
@@ -122,7 +123,7 @@ aside {
 /**
  * Search form
  */
-.search-form {
+.fs-search-form {
   &__label {
     color: $black;
     font-size: .8em;
@@ -165,7 +166,7 @@ aside {
 /**
  * Applied Filters
  */
-.applied-filters {
+.fs-applied-filters {
   &__filter {
     border-bottom: solid 2px $c-secondary;
     font-size: .8em;
@@ -177,7 +178,7 @@ aside {
 /**
  * Search results list
  */
-.search-results {
+.fs-search-results {
   &__heading a {
     background-color: transparent;
     color: $link-color;
@@ -222,7 +223,7 @@ aside {
 /**
  * Pagination component
  */
-.search-pager {
+.fs-search-pager {
   background-color: transparent;
 
   /** pagination component **/

--- a/docs/assets/search_theme_override.scss
+++ b/docs/assets/search_theme_override.scss
@@ -10,23 +10,20 @@
 $black: #222;
 $lighter-black: #333;
 $white: #fff;
-$white-60: rgba($white, .6);
-$white-30: rgba($white, .3);
+$white-60: rgba($white, 0.6);
+$white-30: rgba($white, 0.3);
 $gray-pale: #eff0f1;
 $gray-light: #e5e5e5;
 $gray-medium: #555;
 $gray-dark: #333;
-
 $c-border-gray: #ccc;
 $c-border-gray-dark: #b5b5b5;
 $c-bg-gray: #f6f6f6;
 $c-bg-gray-dark: #d8d8d8;
-
 $c-primary: #00274c;
 $c-primary-pale: #8dbef6;
 $c-primary-light: #0d57aa;
 $c-primary-dark: #002a5b;
-
 $c-secondary: #ffcb05;
 $c-secondary-light: #fff2c0;
 $c-secondary-dark: #f4bb06;
@@ -76,18 +73,18 @@ aside.fs-aside {
 
   /* Search filters clear button */
   &__reset {
-    background-color: $gray-light;
     border: 1px solid $c-border-gray;
     border-radius: 3px;
-    font-size: .8em;
+    background-color: $gray-light;
+    font-size: 0.8em;
     line-height: 1.83333em;
 
     &:active,
     &:hover,
     &:focus {
-      background-color: $c-bg-gray-dark;
-      border-color: $c-border-gray-dark;
       text-decoration: underline;
+      border-color: $c-border-gray-dark;
+      background-color: $c-bg-gray-dark;
     }
   }
 }
@@ -100,21 +97,21 @@ aside.fs-aside {
   &__title {
     color: $link-color;
     border-bottom: 1px solid $gray-light;
-    font-size: .8em;
+    font-size: 0.8em;
 
     &:active,
     &:hover {
-      color: $link-hover;
-      background-color: $gray-light;
-      border-color: $c-border-gray-dark;
       text-decoration: none;
+      color: $link-hover;
+      border-color: $c-border-gray-dark;
+      background-color: $gray-light;
     }
 
     &:focus,
     &.js-search-accordion-open {
+      text-decoration: none;
       color: $link-color;
       border-color: $c-border-gray-dark;
-      text-decoration: none;
     }
   }
 }
@@ -126,13 +123,13 @@ aside.fs-aside {
 .fs-search-form {
   &__label {
     color: $black;
-    font-size: .8em;
+    font-size: 0.8em;
     line-height: 1.83333em;
   }
 
   &__input {
-    border-radius: 3px 0 0 3px;
     border: 1px solid $gray-light;
+    border-radius: 3px 0 0 3px;
 
     &:focus {
       border: 1px solid $gray-medium;
@@ -141,10 +138,10 @@ aside.fs-aside {
   }
 
   &__submit {
-    background-color: $c-secondary;
-    border-radius: 0 3px 3px 0;
     border: 1px solid $gray-light;
     border-left: 0;
+    border-radius: 0 3px 3px 0;
+    background-color: $c-secondary;
 
     svg {
       fill: $black;
@@ -153,8 +150,8 @@ aside.fs-aside {
     &:active,
     &:hover,
     &:focus {
-      background-color: $c-secondary-dark;
       border-color: $gray-light;
+      background-color: $c-secondary-dark;
 
       svg {
         fill: $black;
@@ -168,10 +165,10 @@ aside.fs-aside {
  */
 .fs-applied-filters {
   &__filter {
+    padding-bottom: 0.29333em;
     border-bottom: solid 2px $c-secondary;
-    font-size: .8em;
+    font-size: 0.8em;
     line-height: 1.46667em;
-    padding-bottom: .29333em;
   }
 }
 
@@ -180,30 +177,30 @@ aside.fs-aside {
  */
 .fs-search-results {
   &__heading a {
-    background-color: transparent;
-    color: $link-color;
     text-decoration: none;
+    color: $link-color;
     border-bottom: 2px dashed $link-color;
+    background-color: transparent;
 
     &:active,
     &:hover {
-      outline-width: 0;
       color: $link-hover;
-      background-color: $gray-light;
       border-bottom: 2px solid $link-hover;
+      outline-width: 0;
+      background-color: $gray-light;
     }
   }
 
   /* Search results eyebrow (i.e. the content type). */
   &__label {
     color: $gray-medium;
-    font-size: .8em;
+    font-size: 0.8em;
   }
 
   /* Search results metadata (i.e. the site + date) */
   &__meta {
     color: $c-tertiary;
-    font-size: .8em;
+    font-size: 0.8em;
     line-height: 1.46667em;
   }
 
@@ -215,8 +212,8 @@ aside.fs-aside {
 
   /* highlighted text in snippet */
   em {
+    background-color: rgba($c-secondary-light, 0.85);
     font-weight: 700;
-    background-color: rgba($c-secondary-light, .85);
   }
 }
 
@@ -238,10 +235,9 @@ aside.fs-aside {
 
   /** inactive page links **/
   &__item a {
-
     @media (min-width: $bp0) {
-      background-color: $c-secondary;
       border-radius: 3px;
+      background-color: $c-secondary;
     }
 
     &:hover,
@@ -263,8 +259,8 @@ aside.fs-aside {
   /** active page link **/
   &__item.is-active a {
     @media (min-width: $bp0) {
-      background-color: $c-primary-light;
       color: $white;
+      background-color: $c-primary-light;
 
       &:hover,
       &:active {
@@ -279,8 +275,8 @@ aside.fs-aside {
  */
 // Override default color values with site colors.
 .PresetDateRangePicker_button {
-  border: 2px solid lighten($c-primary-light, 25%);
   color: lighten($c-primary-light, 25%);
+  border: 2px solid lighten($c-primary-light, 25%);
 }
 .PresetDateRangePicker_button__selected {
   color: $white;
@@ -294,8 +290,8 @@ aside.fs-aside {
   border-right: 33px solid darken($c-primary-light, 15%);
 }
 .DayPickerKeyboardShortcuts_show__topRight {
-  border-bottom: 26px solid transparent;
   border-right: 33px solid $c-primary-light;
+  border-bottom: 26px solid transparent;
 }
 .DayPickerKeyboardShortcuts_show__topRight:hover {
   border-right: 33px solid darken($c-primary-light, 15%);
@@ -308,15 +304,15 @@ aside.fs-aside {
   border-left: 33px solid $c-primary;
 }
 .CalendarDay__selected_span {
-  background: lighten($c-primary-light, 60%);
-  border: 1px solid lighten($c-primary-light, 35%);
   color: $c-primary-light;
+  border: 1px solid lighten($c-primary-light, 35%);
+  background: lighten($c-primary-light, 60%);
 }
 .CalendarDay__selected_span:active,
 .CalendarDay__selected_span:hover {
-  background: $c-bg-gray-dark;
-  border: 1px solid $c-border-gray-dark;
   color: $white;
+  border: 1px solid $c-border-gray-dark;
+  background: $c-bg-gray-dark;
 }
 .CalendarDay__last_in_range {
   border-right: lighten($c-primary-light, 25%);
@@ -324,33 +320,33 @@ aside.fs-aside {
 .CalendarDay__selected,
 .CalendarDay__selected:active,
 .CalendarDay__selected:hover {
-  background: $c-primary-light;
-  border: 1px solid $c-primary-light;
   color: $white;
+  border: 1px solid $c-primary-light;
+  background: $c-primary-light;
 }
 .CalendarDay__hovered_span,
 .CalendarDay__hovered_span:hover {
-  background: lighten($c-primary-light, 60%);
-  border: 1px solid lighten($c-primary-light, 35%);
   color: $c-primary-light;
+  border: 1px solid lighten($c-primary-light, 35%);
+  background: lighten($c-primary-light, 60%);
 }
 .CalendarDay__hovered_span:active {
-  background: lighten($c-primary-light, 60%);
-  border: 1px solid lighten($c-primary-light, 35%);
   color: $c-primary-light;
+  border: 1px solid lighten($c-primary-light, 35%);
+  background: lighten($c-primary-light, 60%);
 }
 .DateInput_input__focused {
   border-bottom: 2px solid $c-primary-light;
 }
 
 .CalendarDay__highlighted_calendar {
-  background: $c-secondary-light;
   color: $gray-medium;
+  background: $c-secondary-light;
 }
 .CalendarDay__highlighted_calendar:active,
 .CalendarDay__highlighted_calendar:hover {
-  background: $c-secondary;
   color: $gray-medium;
+  background: $c-secondary;
 }
 
 .DateInput_input::placeholder {
@@ -367,11 +363,11 @@ aside.fs-aside {
   border-radius: 0;
 }
 
-@media only screen and (max-width: 1350px) and (min-width: 901px)  {
+@media only screen and (max-width: 1350px) and (min-width: 901px) {
   .DateInput_input__small {
+    padding: 8px 4px 6px;
     font-size: 12px;
     line-height: 18px;
-    padding: 8px 4px 6px;
   }
 
   .DateInput__small {
@@ -381,21 +377,21 @@ aside.fs-aside {
 
 .KeyboardShortcutRow_keyContainer {
   display: inline-block;
-  white-space: nowrap;
-  text-align: right;
   margin-right: 6px;
+  text-align: right;
+  white-space: nowrap;
 }
 
 .KeyboardShortcutRow_key {
-  font-family: monospace;
-  font-size: 12px;
+  padding: 2px 6px;
   text-transform: uppercase;
   background: $c-bg-gray;
-  padding: 2px 6px;
+  font-family: monospace;
+  font-size: 12px;
 }
 
 .KeyboardShortcutRow_action {
   display: inline;
-  word-break: break-word;
   margin-left: 8px;
+  word-break: break-word;
 }

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -43,6 +43,9 @@ function <your-theme>_page_attachments_alter(array &$page) {
 ### Notes
 The Sass/CSS assets that are included in docs/assets are examples only. They will not be regularly maintained or updated.
 
+### Upgrading from 8.x-2.x to 8.x-3.x
+Starting on version 3.x of the module, the CSS has been updated to a new namespacing. All CSS classes are now updated to have a "fs-" prefix and all styled are applied within the main app ID of `#fs-root`, so any previously written CSS or SCSS overrides for version 2.x will need to be updated to reflect this namespace change. .  
+
 ## Theming the Drupal elements
 
 While the React application is separate from Drupal, the provided search block `Federated Search Page Form block` is themable, as is the wrapper around the search results page. There are three theme files.

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -54,7 +54,7 @@ While the React application is separate from Drupal, the provided search block `
 
 This template instantiates the application itself. It is designed to use the full width of the page. If you override this template in your theme, you must retain the root div element:
 
-`<div id="root" data-federated-search-app-config="{{ app_config }}">`
+`<div id="fs-root" data-federated-search-app-config="{{ app_config }}">`
 
 Without this element, the application will not function.
 

--- a/docs/theme.md
+++ b/docs/theme.md
@@ -44,7 +44,7 @@ function <your-theme>_page_attachments_alter(array &$page) {
 The Sass/CSS assets that are included in docs/assets are examples only. They will not be regularly maintained or updated.
 
 ### Upgrading from 8.x-2.x to 8.x-3.x
-Starting on version 3.x of the module, the CSS has been updated to a new namespacing. All CSS classes are now updated to have a "fs-" prefix and all styled are applied within the main app ID of `#fs-root`, so any previously written CSS or SCSS overrides for version 2.x will need to be updated to reflect this namespace change. .  
+Starting on version 3.x of the module, the CSS has been updated to a new namespacing. All CSS classes are now updated to have a "fs-" prefix and all base styles are applied within the main app ID of `#fs-root`, so any previously written CSS or SCSS overrides for version 2.x will need to be updated to reflect this namespace change.  
 
 ## Theming the Drupal elements
 

--- a/search_api_federated_solr.libraries.yml
+++ b/search_api_federated_solr.libraries.yml
@@ -1,12 +1,18 @@
 search:
-  version: 2.x
+  version: 3.x
   css:
     theme:
-      https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v2.1.4/css/main.ec684809.css:
+      https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v3.0.0-beta1/css/main.d64a4abb.chunk.css:
         type: external
         minified: true
   js:
-    https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v2.1.4/js/main.47024ff2.js:
+    https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v3.0.0-beta1/js/runtime-main.9cb93041.js:
+      preprocess: false
+      minified: true
+    https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v3.0.0-beta1/js/2.7525757a.chunk.js:
+      preprocess: false
+      minified: true
+    https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v3.0.0-beta1/js/main.cd684510.chunk.js:
       preprocess: false
       minified: true
 

--- a/search_api_federated_solr.libraries.yml
+++ b/search_api_federated_solr.libraries.yml
@@ -2,17 +2,17 @@ search:
   version: 3.x
   css:
     theme:
-      https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v3.0.0-beta1/css/main.d64a4abb.chunk.css:
+      https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v3.0.0-beta2/css/main.873142e3.chunk.css:
         type: external
         minified: true
   js:
-    https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v3.0.0-beta1/js/runtime-main.9cb93041.js:
+    https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v3.0.0-beta2/js/runtime-main.9cb93041.js:
       preprocess: false
       minified: true
-    https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v3.0.0-beta1/js/2.7525757a.chunk.js:
+    https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v3.0.0-beta2/js/2.7525757a.chunk.js:
       preprocess: false
       minified: true
-    https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v3.0.0-beta1/js/main.cd684510.chunk.js:
+    https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v3.0.0-beta2/js/main.cd684510.chunk.js:
       preprocess: false
       minified: true
 

--- a/templates/search-app.html.twig
+++ b/templates/search-app.html.twig
@@ -1,7 +1,7 @@
 {% set app_config = federated_search_app_config|json_encode(constant('JSON_UNESCAPED_SLASHES'), constant('JSON_NUMERIC_CHECK')) %}
 
 <noscript>This search page requires Javascript in order to function.  <a href="https://www.whatismybrowser.com/guides/how-to-enable-javascript/auto">Learn how to enable Javascript in your browser</a>.</noscript>
-<div id="root"
+<div id="fs-root"
   data-federated-search-app-config="{{ app_config }}">
   <p class="element-invisible" aria-hidden="true">Federated Solr Search App: If you see this message in your DevTools, it likely means there is an issue adding the app javascript library to this page.  Follow the steps in the search_api_federated_solr module README.</p>
 </div>

--- a/templates/search-app.html.twig
+++ b/templates/search-app.html.twig
@@ -3,5 +3,5 @@
 <noscript>This search page requires Javascript in order to function.  <a href="https://www.whatismybrowser.com/guides/how-to-enable-javascript/auto">Learn how to enable Javascript in your browser</a>.</noscript>
 <div id="fs-root"
   data-federated-search-app-config="{{ app_config }}">
-  <p class="element-invisible" aria-hidden="true">Federated Solr Search App: If you see this message in your DevTools, it likely means there is an issue adding the app javascript library to this page.  Follow the steps in the search_api_federated_solr module README.</p>
+  <p class="fs-element-invisible" aria-hidden="true">Federated Solr Search App: If you see this message in your DevTools, it likely means there is an issue adding the app javascript library to this page.  Follow the steps in the search_api_federated_solr module README.</p>
 </div>


### PR DESCRIPTION
Completes [FS-28](https://palantir.atlassian.net/browse/FS-28)

To Test:
Review documentation and examples for clarity. 

Notes:
Existing documentation looked good so I only added some notes about updating existing override CSS should you be going from 2. to 3.x. 

CSS and SCSS files are updated to match namespace changes. 

Random note: I accidentally pushed to the 3.x branch so I revert-committed and  cherry-picked to here. 