### PR TITLE
Tests using the new 3.0.0-alpha1 release of the react app.

### DIFF
--- a/search_api_federated_solr.libraries.yml
+++ b/search_api_federated_solr.libraries.yml
@@ -1,12 +1,18 @@
 search:
-  version: 2.x
+  version: 3.x
   css:
     theme:
-      https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v2.1.4/css/main.ec684809.css:
+      https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v3.0.0-alpha1/css/main.afef02de.chunk.css:
         type: external
         minified: true
   js:
-    https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v2.1.4/js/main.47024ff2.js:
+    https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v3.0.0-alpha1/js/runtime-main.9cb93041.js:
+      preprocess: false
+      minified: true
+    https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v3.0.0-alpha1/js/2.7525757a.chunk.js:
+      preprocess: false
+      minified: true
+    https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v3.0.0-alpha1/js/main.fcafe349.chunk.js:
       preprocess: false
       minified: true
 

--- a/search_api_federated_solr.module
+++ b/search_api_federated_solr.module
@@ -174,7 +174,7 @@ function search_api_federated_solr_search_api_solr_documents_alter(array &$docum
       $default_language_id = \Drupal::languageManager()->getDefaultLanguage()->getId();
       $string = $default_language_id . '_rendered_item';
 
-      if (substr_count($field_id, $string) > 0 && substr_count($field_id, $string) > 0) {
+      if (substr_count($field_id, $string) > 0 && substr_count($field_id, 'sort_') === 0) {
         $boost = $document->getFieldBoost($field_id);
         $modifier = $document->getFieldModifier($field_id);
 


### PR DESCRIPTION
Tests out the app using the new build from https://github.com/palantirnet/federated-search-react/pull/59

To test:

* Go to the `src/search_api_federated_solr` directory of the demo site.
* `git checkout 3.0-alpha`
* Clear the Drupal cache (`drush @d8 cr`)
* Test the application.

We should now have these script files loaded:

```
<script src="https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v3.0.0-alpha1/js/runtime-main.9cb93041.js"></script>
<script src="https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v3.0.0-alpha1/js/2.7525757a.chunk.js"></script>
<script src="https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v3.0.0-alpha1/js/main.fcafe349.chunk.js"></script>
```

And this CSS:

```
<link rel="stylesheet" media="all" href="https://cdn.jsdelivr.net/gh/palantirnet/federated-search-react@v3.0.0-alpha1/css/main.afef02de.chunk.css" />
```