### PR TITLE
Match info.yml version requirement to composer.json constraint

### DIFF
--- a/search_api_federated_solr.info.yml
+++ b/search_api_federated_solr.info.yml
@@ -6,6 +6,6 @@ core_version_requirement: ^8 || ^9
 package: Search
 dependencies:
   - drupal:field
-  - search_api_field_map:search_api_field_map (>=8.x-3.x)
+  - search_api_field_map:search_api_field_map (>=8.x-4.x)
   - search_api_solr:search_api_solr
   - token:token


### PR DESCRIPTION
https://github.com/palantirnet/search_api_federated_solr/blob/4.x/composer.json contains a version constraint of `^4.0`. The `info.yml` file needs to be updated with a similar requirement.